### PR TITLE
Modernize site: bilingual redesign, SEO/accessibility, 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr-CA">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#F5F5F2">
+    <meta name="robots" content="noindex, follow">
+    <title>Page introuvable — Page not found | Qualitech Électricité</title>
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260719h">
+    <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon">
+</head>
+
+<body>
+    <header class="site-header">
+        <a class="brand" href="/" aria-label="Accueil Qualitech Électricité">
+            <img src="/assets/images/QE Logo.webp" alt="Logo Qualitech Électricité Inc." width="1200" height="200">
+        </a>
+    </header>
+
+    <main>
+        <section class="section not-found">
+            <div class="section-header">
+                <p class="eyebrow">Erreur 404</p>
+                <h1>Page introuvable.</h1>
+            </div>
+            <p>La page demandée n'existe pas ou a été déplacée.</p>
+            <div class="hero-actions">
+                <a class="button primary" href="/">Retour à l'accueil</a>
+            </div>
+            <div class="not-found-en" lang="en">
+                <h2>Page not found.</h2>
+                <p>The page you requested does not exist or has moved.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="/index-en.html">Go to the English homepage</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year">2026</span> Qualitech Électricité Inc. Tous droits réservés. — All rights reserved.</p>
+        <p class="footer-rbq">RBQ&nbsp;: 5811-4398-01</p>
+    </footer>
+
+    <script src="/assets/js/main.js?v=20260719g" defer></script>
+</body>
+
+</html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# qualitech-el
+# Qualitech Électricité Inc. website
+
+Static bilingual website for Qualitech Électricité Inc., a residential, commercial, and industrial electrical contractor, hosted on GitHub Pages.
+
+## Pages
+
+- `index.html`: French homepage and canonical default page.
+- `index-en.html`: English homepage.
+- `index-fr.html`: French compatibility page, canonicalized to `/`.
+- `404.html`: bilingual not-found page served by GitHub Pages for missing URLs.
+- `robots.txt`, `sitemap.xml`, and `llms.txt`: crawl and AI-discovery support files.
+
+## Branding colours
+
+The website uses an approximate palette derived from the company logo and branded vehicle photography.
+
+| Colour | Value | Website role |
+| --- | --- | --- |
+| Carbon black | `#171B20` | Primary text, footer, and high-contrast details |
+| Graphite | `#292E33` | Hero, industrial, and service-area backgrounds |
+| Branded orange | `#F36A1D` | Primary calls to action and structural accents |
+| Accessible dark orange | `#B84500` | Rating stars and small orange text on light surfaces |
+| Electrical amber | `#FFAE00` | Sparks, energized effects, and accents on dark backgrounds |
+| Electric blue | `#076BC7` | Links, focus states, borders, and accents on light backgrounds |
+| Warm white | `#F5F5F2` | Page, banner, and primary content surfaces |
+
+Supporting interface neutrals are panel grey `#EDEDEA`, line grey `#D4D5D3`, and muted text grey `#5B6064`.
+
+For accessible contrast, orange buttons use carbon text, blue is used for small text on light surfaces, and amber is used for small accents on graphite. These screen colours are photo-derived approximations, not vehicle-wrap production specifications. Official Pantone, CMYK, vinyl-film, or sign-production values should supersede these approximations if they become available.
+
+## Notes
+
+The site is intentionally static so it can remain on GitHub Pages. French is the default language, with a complete English version available from the language switch. Public Google review links open in new tabs. Review excerpts are manually curated from the public Google listing; any future live review feed should use a serverless proxy or static sync process so no Google API key is exposed in browser JavaScript.
+
+An explicit language choice is remembered on the visitor's device with the `qualitech-language` local-storage value. No cookie is created and no language preference is sent to the server. First-time visitors and visitors with unavailable browser storage receive the French default page.
+
+## Online quote request status and limitations
+
+The website's **Request a quote / Demander une soumission** buttons and quote forms are currently hidden while Qualitech chooses a submission method. The bilingual form markup and styling remain in the site for possible reuse, but visitors cannot reach or submit it through the rendered pages. Telephone contact remains available. Clicking the displayed email address copies it to the clipboard and shows a short confirmation toast; without JavaScript, the same element remains a standard `mailto:` link. If clipboard access fails, the script falls back to opening the `mailto:` link.
+
+GitHub Pages publishes static files only. It cannot receive a form submission, store a lead, send an email, protect a mail-server credential, run server-side validation, or process an uploaded photograph. A complete online request workflow therefore needs a separate form backend or serverless endpoint even when the public website continues to be hosted on GitHub Pages.
+
+The current dormant form handler prepares a structured `mailto:` message. It has important limitations and should not be exposed as the primary quote workflow:
+
+- It depends on the visitor having a default email application or browser email-protocol handler configured.
+- Visitors who only use browser-based Gmail, Outlook, or another webmail service may see nothing happen after pressing the button.
+- The website cannot confirm that the visitor reviewed or sent the prepared email.
+- Attachments cannot be added automatically; the visitor must attach photographs in their email application.
+- Mobile and desktop operating systems may handle `mailto:` links differently.
+- The website receives no delivery status, searchable submission record, spam filtering, retry mechanism, or notification if the handoff fails.
+
+Any future automatic submission option must be assessed for:
+
+- French and English form parity, validation messages, confirmation messages, and customer emails.
+- Where customer names, phone numbers, email addresses, project locations, descriptions, and photographs are processed and retained.
+- A privacy notice, retention/deletion policy, and any required consent language.
+- Spam and abuse controls such as a honeypot, rate limiting, CAPTCHA, file-type checks, and upload-size limits.
+- Email deliverability, sender-domain authentication, failure notifications, service quotas, recurring cost, vendor availability, and account ownership.
+- Keeping mail-service credentials and API secrets outside the GitHub repository and browser JavaScript.
+- A direct telephone and email fallback if the submission service is unavailable.
+
+Possible approaches include a managed static-form backend or a Qualitech-controlled serverless endpoint connected to a transactional email provider. Neither option is part of GitHub Pages itself, and neither should be enabled until the company owner approves the provider, account ownership, data handling, expected cost, and operational responsibility.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,354 +1,1074 @@
-body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
-    line-height: 1.6;
-    color: #333;
-    overflow-x: hidden;
+:root {
+    color-scheme: only light;
+    --carbon: #171b20;
+    --graphite: #292e33;
+    --brand-orange: #f36a1d;
+    --brand-orange-dark: #b84500;
+    --electrical-amber: #ffae00;
+    --electric-blue: #076bc7;
+    --electric-blue-dark: #005aa8;
+    --warm-white: #f5f5f2;
+    --white: #ffffff;
+    --panel: #ededea;
+    --muted: #5b6064;
+    --line: #d4d5d3;
+    --text-on-dark-muted: rgb(245 245 242 / 0.82);
+    --carbon-rgb: 23 27 32;
+    --graphite-rgb: 41 46 51;
+    --orange-rgb: 243 106 29;
+    --amber-rgb: 255 174 0;
+    --blue-rgb: 7 107 199;
+    --warm-white-rgb: 245 245 242;
+    --panel-rgb: 237 237 234;
+    --shadow: 0 18px 50px rgb(var(--carbon-rgb) / 0.14);
 }
 
-header {
+* {
+    box-sizing: border-box;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    color: var(--carbon);
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: 1.6;
+    background: var(--warm-white);
+}
+
+img {
+    display: block;
+    max-width: 100%;
+}
+
+a {
+    color: inherit;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+}
+
+.site-header {
+    position: sticky;
+    /* Stick with the banner scrolled out of view so only the nav row stays
+       pinned; the offset mirrors the fluid banner height: the logo renders at
+       min(86vw, 1040px) with a 6:1 ratio (so its height is min(14.333333vw,
+       173.333333px)), plus 18px + 14px padding, 5px border, and a 2px
+       overshoot buffer. Browsers without min() fall back to a fully sticky
+       header. */
+    top: 0;
+    top: calc(-39px - min(14.333333vw, 173.333333px));
+    z-index: 20;
+    isolation: isolate;
+    display: block;
+    padding: 0;
+    background: rgb(var(--warm-white-rgb) / 0.96);
+    border-bottom: 2px solid rgb(var(--blue-rgb) / 0.52);
+    box-shadow: 0 8px 24px rgb(var(--carbon-rgb) / 0.1);
+    backdrop-filter: blur(12px);
+}
+
+.site-header::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: -3px;
+    left: 0;
+    z-index: 2;
+    height: 4px;
+    pointer-events: none;
+    background-image: linear-gradient(90deg, transparent 0, rgb(var(--amber-rgb) / 0.25) 30%, var(--white) 52%, var(--brand-orange) 58%, transparent 100%);
+    background-repeat: no-repeat;
+    background-position: -180px 50%;
+    background-size: 180px 100%;
+    filter: drop-shadow(0 0 5px rgb(var(--amber-rgb) / 0.95)) drop-shadow(0 0 9px rgb(var(--blue-rgb) / 0.7));
+    animation: wire-current 4.8s linear infinite;
+}
+
+@keyframes wire-current {
+    to {
+        background-position: calc(100% + 180px) 50%;
+    }
+}
+
+.brand {
     display: flex;
     justify-content: center;
-    align-items: center;
-    padding: 10px 20px;
-    background-color: #f4f4f4;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    padding: 18px clamp(18px, 4vw, 56px) 14px;
+    border-top: 5px solid var(--brand-orange);
+    background: var(--warm-white);
 }
 
-header img {
-    max-height: 200px;
+.brand img {
+    width: min(86vw, 1040px);
+    height: auto;
+}
+
+.site-nav {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px clamp(18px, 4vw, 56px);
+    border-top: 1px solid var(--line);
+    background: rgb(var(--panel-rgb) / 0.94);
+    backdrop-filter: blur(12px);
 }
 
 .language-switch {
-    margin-left: auto;
-    position: relative;
-    display: inline-block;
-    padding-right: 5px;
+    position: absolute;
+    right: clamp(18px, 4vw, 56px);
 }
 
-.language-switch a {
-    padding: 10px 15px;
-    background-color: #007BFF;
-    color: white;
-    text-decoration: none;
-    border-radius: 5px;
-    transition: background-color 0.3s ease;
-}
-
-.language-switch a:hover {
-    background-color: #0056b3; 
-}
-
-.language-switch a::after {
-    content: attr(data-long-text);
-}
-
-.subheader-panel {
-    background-color: #FFA500;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 20px;
-    margin-bottom: 20px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
-    max-width: 100vw;
-    box-sizing: border-box;
-}
-
-.subheader-items-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-grow: 1;
-    flex-wrap: nowrap;
-    gap: 10px;
-    overflow: hidden;
-    white-space: nowrap;
-    box-sizing: border-box;
-}
-
-.subheader-item {
-    font-size: 1em;
-    color: white;
-    cursor: pointer;
-    margin: 0 15px;
-    padding: 5px 10px;
-    border-radius: 5px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 120px;
-    transition: background-color 0.3s ease, color 0.3s ease, padding 0.3s ease;
-    display: inline-block;
-}
-
-.subheader-item:hover {
-    background-color: rgba(255, 255, 255, 0.2);
-}
-
-.subheader-item.active {
-    background-color: white;
-    color: #FFA500;
-}
-
-.carousel-container {
-    position: relative;
-    width: 90%;
-    max-width: 1200px;
-    margin: 0 auto;
-    height: 70vh;
-    overflow: hidden;
-    border-radius: 10px;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-}
-
-.carousel-slide {
+.language-short {
     display: none;
+}
+
+.site-nav a {
+    padding: 10px 12px;
+    border-radius: 6px;
+    color: var(--graphite);
+    font-size: 0.95rem;
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+    background: var(--warm-white);
+    color: var(--electric-blue-dark);
+}
+
+.site-nav .nav-cta {
+    background: var(--brand-orange);
+    color: var(--carbon);
+}
+
+.site-nav .nav-cta:hover,
+.site-nav .nav-cta:focus-visible {
+    background: var(--electrical-amber);
+    color: var(--carbon);
+}
+
+.site-nav a[href^="#"] {
+    position: relative;
+}
+
+.site-nav a[aria-current="location"] {
+    color: var(--electric-blue-dark);
+}
+
+.site-nav a[aria-current="location"]::after {
+    content: "";
+    position: absolute;
+    right: 12px;
+    bottom: 3px;
+    left: 12px;
+    height: 3px;
+    border-radius: 999px;
+    background: var(--brand-orange);
+}
+
+.menu-toggle {
+    display: none;
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--warm-white);
+}
+
+.menu-toggle span:not(.sr-only) {
+    display: block;
+    width: 20px;
+    height: 2px;
+    margin: 4px auto;
+    background: var(--carbon);
+    transition: transform 180ms ease, opacity 180ms ease;
+}
+
+.menu-toggle[aria-expanded="true"] span:nth-of-type(1) {
+    transform: translateY(6px) rotate(45deg);
+}
+
+.menu-toggle[aria-expanded="true"] span:nth-of-type(2) {
+    opacity: 0;
+}
+
+.menu-toggle[aria-expanded="true"] span:nth-of-type(3) {
+    transform: translateY(-6px) rotate(-45deg);
+}
+
+.hero {
+    min-height: calc(100vh - 82px);
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr);
+    align-items: stretch;
+    background: var(--graphite);
+    color: var(--warm-white);
+}
+
+.hero-media {
+    min-height: 520px;
+    background-image: linear-gradient(90deg, rgb(var(--graphite-rgb) / 0.12), rgb(var(--graphite-rgb) / 0.76)), url("../images/commercial.webp");
+    background-position: center;
+    background-size: cover;
+}
+
+.hero-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 22px;
+    padding: clamp(34px, 4.2vw, 68px);
+    background-image:
+        radial-gradient(circle at 82% 18%, rgb(var(--orange-rgb) / 0.16), transparent 30%),
+        linear-gradient(rgb(var(--warm-white-rgb) / 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(var(--warm-white-rgb) / 0.03) 1px, transparent 1px);
+    background-size: auto, 34px 34px, 34px 34px;
+}
+
+.eyebrow {
+    margin: 0;
+    color: var(--electric-blue);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.hero .eyebrow,
+.industrial-callout .eyebrow,
+.split .eyebrow {
+    color: var(--electrical-amber);
+}
+
+h1,
+h2,
+h3,
+p {
+    margin-top: 0;
+}
+
+h1 {
+    max-width: 780px;
+    margin-bottom: 0;
+    font-size: clamp(2.35rem, 4vw, 3.75rem);
+    line-height: 1.03;
+    letter-spacing: 0;
+}
+
+h2 {
+    margin-bottom: 0;
+    font-size: clamp(1.9rem, 4vw, 3.15rem);
+    line-height: 1.08;
+    letter-spacing: 0;
+}
+
+h3 {
+    margin-bottom: 8px;
+    font-size: 1.2rem;
+    line-height: 1.2;
+}
+
+.hero-copy {
+    max-width: 640px;
+    margin-bottom: 0;
+    color: var(--text-on-dark-muted);
+    font-size: 1.18rem;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 12px 18px;
+    border: 2px solid transparent;
+    border-radius: 6px;
+    font-weight: 800;
+    text-decoration: none;
+}
+
+.button.primary {
+    background: var(--brand-orange);
+    color: var(--carbon);
+}
+
+.button.primary:hover,
+.button.primary:focus-visible {
+    background: var(--electrical-amber);
+}
+
+.button.secondary {
+    border-color: rgb(var(--warm-white-rgb) / 0.6);
+    color: var(--warm-white);
+}
+
+.reviews .button.secondary {
+    border-color: var(--electric-blue);
+    color: var(--electric-blue-dark);
+}
+
+.button:hover,
+.button:focus-visible {
+    transform: translateY(-1px);
+}
+
+.trust-list {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+    margin: 18px 0 0;
+}
+
+.trust-list div {
+    padding: 14px;
+    border: 1px solid rgb(var(--warm-white-rgb) / 0.2);
+    border-radius: 8px;
+    background: rgb(var(--warm-white-rgb) / 0.08);
+}
+
+.trust-list dt {
+    color: rgb(var(--warm-white-rgb) / 0.72);
+    font-size: 0.78rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.trust-list dd {
+    margin: 4px 0 0;
+    font-weight: 800;
+}
+
+.section {
+    padding: clamp(56px, 8vw, 100px) clamp(18px, 4vw, 56px);
+    scroll-margin-top: 80px;
+}
+
+.section-header {
+    max-width: 860px;
+    margin-bottom: 34px;
+}
+
+.intro {
+    display: grid;
+    grid-template-columns: minmax(0, 0.9fr) minmax(280px, 0.75fr);
+    gap: clamp(28px, 6vw, 80px);
+    background: var(--panel);
+}
+
+.intro-copy {
+    color: var(--muted);
+    font-size: 1.06rem;
+}
+
+.services {
+    background:
+        radial-gradient(circle at 92% 10%, rgb(var(--orange-rgb) / 0.09), transparent 24%),
+        var(--warm-white);
+}
+
+.services,
+.reviews,
+.faq {
+    position: relative;
+}
+
+.services::before,
+.reviews::before,
+.faq::before {
+    content: "";
     position: absolute;
     top: 0;
-    left: 0;
+    right: clamp(18px, 4vw, 56px);
+    left: clamp(18px, 4vw, 56px);
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--electric-blue), var(--brand-orange), var(--electrical-amber), transparent);
+}
+
+.service-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 20px;
+}
+
+.service-card {
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--white);
+    box-shadow: 0 10px 28px rgb(var(--carbon-rgb) / 0.08);
+    transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.service-card:hover,
+.service-card:focus-within {
+    transform: translateY(-4px);
+    border-color: rgb(var(--blue-rgb) / 0.5);
+    box-shadow: 0 18px 38px rgb(var(--carbon-rgb) / 0.15);
+}
+
+.service-card img {
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
+}
+
+.service-card div {
+    padding: 22px;
+}
+
+.service-card p {
+    margin-bottom: 0;
+    color: var(--muted);
+}
+
+.feature-list {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+    margin: 26px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.feature-list li {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 9px 12px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--panel);
+    color: var(--graphite);
+    font-weight: 800;
+    text-align: center;
+}
+
+.industrial-callout {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.7fr) minmax(300px, 1fr);
+    gap: clamp(24px, 5vw, 64px);
+    align-items: center;
+    margin-top: 30px;
+    padding: clamp(26px, 4vw, 44px);
+    overflow: hidden;
+    border: 1px solid rgb(var(--orange-rgb) / 0.5);
+    border-radius: 8px;
+    color: var(--warm-white);
+    background-color: var(--graphite);
+    background-image:
+        radial-gradient(circle at 88% 22%, rgb(var(--orange-rgb) / 0.22), transparent 24%),
+        linear-gradient(rgb(var(--warm-white-rgb) / 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(var(--warm-white-rgb) / 0.04) 1px, transparent 1px);
+    background-size: auto, 28px 28px, 28px 28px;
+    box-shadow: var(--shadow);
+}
+
+.industrial-callout h3 {
+    margin: 0;
+    font-size: clamp(1.55rem, 3vw, 2.25rem);
+}
+
+.industrial-callout > p {
+    margin: 0;
+    color: var(--text-on-dark-muted);
+    font-size: 1.06rem;
+}
+
+.split {
+    display: grid;
+    grid-template-columns: minmax(0, 0.95fr) minmax(280px, 0.75fr);
+    gap: clamp(28px, 6vw, 80px);
+    background-color: var(--graphite);
+    background-image:
+        radial-gradient(circle at 12% 80%, rgb(var(--blue-rgb) / 0.24), transparent 30%),
+        linear-gradient(rgb(var(--warm-white-rgb) / 0.025) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(var(--warm-white-rgb) / 0.025) 1px, transparent 1px);
+    background-size: auto, 38px 38px, 38px 38px;
+    color: var(--warm-white);
+}
+
+.split p {
+    color: var(--text-on-dark-muted);
+}
+
+.service-area {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    grid-template-columns: minmax(0, 920px);
+    justify-content: center;
+    min-height: 430px;
+    text-align: center;
+}
+
+.service-area::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background:
+        radial-gradient(circle at 14% 80%, rgb(var(--blue-rgb) / 0.28), transparent 32%),
+        linear-gradient(90deg, rgb(var(--graphite-rgb) / 0.84), rgb(var(--graphite-rgb) / 0.68));
+}
+
+.service-area__map {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
     width: 100%;
     height: 100%;
-    background-size: cover;
-    background-position: center;
-    transition: opacity 0.5s ease, transform 0.5s ease;
+    border: 0;
+    pointer-events: none;
+    filter: grayscale(0.32) saturate(0.78) contrast(0.92);
 }
 
-.carousel-slide.active {
-    display: block;
-}
-
-.carousel-header {
-    position: absolute;
-    top: 20px;
-    left: 20px;
-    background: rgba(255, 255, 255, 0.8);
-    padding: 10px 20px;
-    border-radius: 8px;
-    max-width: 600px;
-    font-size: 1.6em;
-}
-
-.carousel-content {
-    position: absolute;
-    bottom: 50px;
-    left: 20px;
-    background: rgba(255, 255, 255, 0.8);
-    padding: 20px;
-    border-radius: 8px;
-    max-width: 600px;
-}
-
-.carousel-nav {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    padding: 0 10px;
-    box-sizing: border-box;
-}
-
-.carousel-nav button {
-    background-color: rgba(0, 0, 0, 0.6);
-    color: #fff;
-    border: none;
-    width: 60px;
-    height: 60px;
-    cursor: pointer;
-    font-size: 30px;
-    border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transition: background-color 0.3s ease;
-}
-
-.carousel-nav button:hover {
-    background-color: rgba(0, 0, 0, 0.8);
-}
-
-
-.carousel-dots {
-    text-align: center;
-    margin-top: 15px;
+.service-area__content {
     position: relative;
-    bottom: 0;
-    padding-top: 10px;
+    z-index: 2;
 }
 
-.carousel-dots .dot {
-    height: 15px;
-    width: 15px;
-    margin: 0 5px;
-    background-color: #bbb;
-    border-radius: 50%;
-    display: inline-block;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
+.service-area p:last-child {
+    max-width: 760px;
+    margin: 22px auto 0;
 }
 
-.carousel-dots .active {
-    background-color: #717171;
+.map-attribution {
+    position: absolute;
+    right: 14px;
+    bottom: 12px;
+    z-index: 3;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: rgb(var(--warm-white-rgb) / 0.94);
+    color: var(--carbon);
+    font-size: 0.75rem;
+    line-height: 1.35;
 }
 
-#contact {
-    background-color: #f4f4f4;
-    padding: 10px;
-    text-align: center;
-    margin-top: 10px;
+.map-attribution a {
+    color: var(--electric-blue-dark);
+    font-weight: 700;
+}
+
+.reviews {
+    background: var(--panel);
+}
+
+.review-panel {
+    width: 100%;
+    max-width: 1500px;
+    margin-inline: auto;
+    padding: clamp(28px, 5vw, 54px);
+    border-left: 8px solid var(--electric-blue);
+    border-radius: 8px;
+    background: var(--white);
+    box-shadow: var(--shadow);
+}
+
+.review-panel p {
+    color: var(--muted);
+}
+
+.review-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 18px;
+    margin: 30px 0;
+}
+
+.review-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 0;
+    padding: 22px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--warm-white);
+}
+
+.review-stars {
+    color: var(--brand-orange-dark);
+    font-size: 1.05rem;
+    letter-spacing: 0.12em;
+}
+
+.review-card blockquote {
+    flex: 1;
+    margin: 0;
+}
+
+.review-card blockquote p {
+    margin: 0;
+    color: var(--graphite);
+}
+
+.review-card figcaption {
+    color: var(--muted);
+    font-size: 0.9rem;
+    font-weight: 800;
+}
+
+.faq {
+    background: var(--warm-white);
+}
+
+.faq-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+}
+
+.faq-grid article {
+    padding: 24px;
+    border: 1px solid var(--line);
     border-radius: 8px;
 }
 
-#contact h2 {
-    font-size: 2em;
-    margin-bottom: 5px;
-    line-height: 1.4;
+.faq-grid p {
+    margin-bottom: 0;
+    color: var(--muted);
 }
 
-#contact ul {
-    list-style: none;
-    padding: 0;
+.quote-section {
+    display: grid;
+    grid-template-columns: minmax(0, 0.72fr) minmax(520px, 1.28fr);
+    gap: clamp(32px, 6vw, 90px);
+    align-items: start;
+    background:
+        linear-gradient(rgb(var(--carbon-rgb) / 0.025) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(var(--carbon-rgb) / 0.025) 1px, transparent 1px),
+        var(--warm-white);
+    background-size: 34px 34px, 34px 34px, auto;
 }
 
-#contact ul li {
-    margin-bottom: 5px;
-    line-height: 1.4;
+.quote-intro {
+    position: sticky;
+    top: 90px;
 }
 
+.quote-intro > p:not(.eyebrow) {
+    color: var(--muted);
+}
 
-#contact ul li a {
-    color: #007BFF;
+.quote-intro .form-note {
+    padding-left: 14px;
+    border-left: 3px solid var(--electric-blue);
+    font-size: 0.9rem;
+}
+
+.quote-form {
+    padding: clamp(22px, 3vw, 36px);
+    border: 1px solid var(--line);
+    border-top: 5px solid var(--brand-orange);
+    border-radius: 8px;
+    background: var(--white);
+    box-shadow: var(--shadow);
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+    margin-bottom: 24px;
+}
+
+.quote-form label {
+    display: block;
+    color: var(--graphite);
+    font-size: 0.9rem;
+    font-weight: 800;
+}
+
+.quote-form label > span {
+    color: var(--brand-orange-dark);
+}
+
+.quote-form input,
+.quote-form select,
+.quote-form textarea {
+    width: 100%;
+    min-height: 48px;
+    margin-top: 6px;
+    padding: 11px 12px;
+    border: 1px solid #aeb1b2;
+    border-radius: 6px;
+    background: var(--white);
+    color: var(--carbon);
+    font: inherit;
+    font-weight: 400;
+}
+
+.quote-form textarea {
+    min-height: 142px;
+    resize: vertical;
+}
+
+.quote-form input:focus,
+.quote-form select:focus,
+.quote-form textarea:focus {
+    border-color: var(--electric-blue);
+    outline: 3px solid rgb(var(--blue-rgb) / 0.2);
+    outline-offset: 1px;
+}
+
+.quote-form .form-span {
+    grid-column: 1 / -1;
+}
+
+.quote-form .button {
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 800;
+}
+
+.form-status {
+    min-height: 1.6em;
+    margin: 12px 0 0;
+    color: var(--electric-blue-dark);
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+.contact-section {
+    display: grid;
+    grid-template-columns: minmax(0, 0.95fr) minmax(280px, 0.75fr);
+    gap: clamp(24px, 5vw, 70px);
+    align-items: center;
+    padding: clamp(48px, 7vw, 86px) clamp(18px, 4vw, 56px);
+    background:
+        radial-gradient(circle at 88% 18%, rgb(var(--blue-rgb) / 0.14), transparent 30%),
+        radial-gradient(circle at 8% 84%, rgb(var(--amber-rgb) / 0.12), transparent 25%),
+        var(--panel);
+    scroll-margin-top: 80px;
+}
+
+.contact-section p {
+    color: var(--muted);
+}
+
+.contact-card {
+    display: grid;
+    gap: 12px;
+    padding: 24px;
+    border-radius: 8px;
+    background: var(--white);
+    box-shadow: var(--shadow);
+    font-style: normal;
+}
+
+.contact-card a {
+    color: var(--electric-blue-dark);
+    font-size: 1.1rem;
+    font-weight: 800;
+}
+
+.email-copy {
+    width: fit-content;
     text-decoration: none;
-    transition: color 0.3s ease;
 }
 
-#contact ul li a:hover {
+.email-copy span {
+    display: block;
+    overflow-wrap: anywhere;
+}
+
+.email-copy small {
+    display: block;
+    margin-top: 2px;
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+.email-copy:hover span,
+.email-copy:focus-visible span {
     text-decoration: underline;
 }
 
-footer {
-    padding: 20px;
+.copy-toast {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 50;
+    max-width: min(360px, calc(100vw - 36px));
+    padding: 12px 16px;
+    border-left: 4px solid var(--electrical-amber);
+    border-radius: 6px;
+    background: var(--carbon);
+    color: var(--warm-white);
+    font-size: 0.9rem;
+    font-weight: 800;
+    box-shadow: var(--shadow);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(10px);
+    transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.copy-toast.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.not-found p {
+    color: var(--muted);
+}
+
+.not-found-en {
+    margin-top: 48px;
+    padding-top: 34px;
+    border-top: 1px solid var(--line);
+}
+
+.site-footer {
+    padding: 26px clamp(18px, 4vw, 56px);
+    background: var(--carbon);
+    color: var(--text-on-dark-muted);
     text-align: center;
-    background-color: #f4f4f4;
-    margin-top: 20px;
-    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
 }
 
-@media (max-width: 768px) {
+.site-footer p {
+    margin: 0;
+}
 
-    header {
-        padding: 2px 0px;
+.site-footer .footer-rbq {
+    margin-top: 4px;
+    font-size: 0.85rem;
+}
+
+.mobile-call {
+    display: none;
+}
+
+@media (max-width: 1120px) {
+    .section,
+    .contact-section {
+        scroll-margin-top: 150px;
     }
 
-    header img {
-        width: 100%;
-        height: auto;
+    .site-header {
+        top: 0;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 44px;
+        align-items: center;
+        column-gap: 14px;
+        padding: 0 18px 0 0;
+        border-top: 5px solid var(--brand-orange);
     }
 
-    .carousel-container {
-        width: 100%;
-        height: 60vh;
+    .brand {
+        justify-content: flex-start;
+        padding: 13px 0 13px 18px;
+        border-top: 0;
     }
 
-    .carousel-content {
-        bottom: 20px;
-        left: 10px;
+    .brand img {
+        width: min(74vw, 620px);
+    }
+
+    .menu-toggle {
+        display: block;
+    }
+
+    .site-nav {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 18px;
+        left: 18px;
+        display: none;
+        flex-direction: column;
+        align-items: stretch;
         padding: 10px;
-        max-width: 90%;
-        font-size: 0.9em;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--warm-white);
+        box-shadow: var(--shadow);
     }
 
-    .carousel-header {
-        top: 10px;
-        left: 10px;
-        padding: 10px;
-        font-size: 1.4em;
-        max-width: 90%;
+    .language-switch {
+        position: static;
     }
 
-    .carousel-nav button {
-        width: 40px;
-        height: 40px;
-        font-size: 16px;
+    .language-long {
+        display: none;
+    }
+
+    .language-short {
+        display: inline;
+    }
+
+    .site-nav.is-open {
+        display: flex;
+    }
+
+    .site-nav a[aria-current="location"] {
+        background: rgb(var(--blue-rgb) / 0.1);
+        box-shadow: inset 4px 0 0 var(--electric-blue);
+    }
+
+    .site-nav a[aria-current="location"]::after {
+        display: none;
+    }
+
+    .hero,
+    .intro,
+    .split,
+    .quote-section,
+    .contact-section,
+    .industrial-callout {
+        grid-template-columns: 1fr;
+    }
+
+    .quote-intro {
+        position: static;
+    }
+
+    .hero {
+        min-height: auto;
+    }
+
+    .hero-media {
+        min-height: 340px;
+        order: 2;
+    }
+
+    .hero-content {
+        order: 1;
+    }
+
+    .service-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .feature-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .review-grid {
+        grid-template-columns: 1fr;
     }
 }
 
-@media (max-width: 480px) {
-
-    .subheader-item {
-        padding: 2px 3px;
-        margin: 0;
-        font-size: 0.8em;
-        display: inline-block;
-        max-width: 90px;
+@media (max-width: 640px) {
+    .section,
+    .contact-section {
+        scroll-margin-top: 96px;
     }
 
-    .subheader-panel {
-        padding: 5px 5px;
+    body {
+        padding-bottom: 64px;
     }
 
-    .language-switch a {
-        padding: 5px 8px;
+    .brand img {
+        width: min(74vw, 430px);
     }
 
-    .language-switch a::after {
-        content: attr(data-short-text);
-        font-size: 0.9em;
+    .site-header::after {
+        height: 3px;
+        animation-duration: 6.5s;
     }
 
-    .carousel-container {
-        height: 50vh;
+    h1 {
+        font-size: 2.35rem;
     }
 
-    .carousel-content {
-        bottom: 10px;
-        left: 5px;
-        padding: 8px;
-        max-width: 90%;
-        font-size: 0.8em;
+    .hero-content,
+    .section,
+    .contact-section {
+        padding-left: 18px;
+        padding-right: 18px;
     }
 
-    .carousel-header {
-        top: 5px;
-        left: 5px;
-        padding: 8px;
-        font-size: 1.2em;
-        max-width: 90%;
+    .trust-list,
+    .faq-grid,
+    .form-grid {
+        grid-template-columns: 1fr;
     }
 
-    .carousel-nav button {
-        width: 30px;
-        height: 30px;
-        font-size: 14px;
+    .quote-form .form-span {
+        grid-column: auto;
     }
 
-    #contact {
-        padding: 8px;
+    .button {
+        width: 100%;
     }
 
-    #contact h2 {
-        font-size: 1.5em;
-        margin-bottom: 3px;
-        line-height: 1.2;
+    .feature-list {
+        grid-template-columns: 1fr;
     }
 
-    #contact ul li {
-        font-size: 0.9em;
-        margin-bottom: 3px;
-        line-height: 1.2;
+    .mobile-call.is-visible {
+        position: fixed;
+        right: 12px;
+        bottom: 12px;
+        left: 12px;
+        z-index: 30;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 52px;
+        border-radius: 6px;
+        background: var(--brand-orange);
+        color: var(--carbon);
+        font-weight: 900;
+        text-decoration: none;
+        box-shadow: var(--shadow);
     }
 
-    #contact ul li a {
-        font-size: 0.9em;
+    .copy-toast {
+        right: 18px;
+        bottom: 78px;
+        left: 18px;
+        max-width: none;
+        text-align: center;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
     }
 
-    footer {
-        padding: 10px;
-        margin-top: 15px;
-        font-size: 0.8em;
+    .site-header::after {
+        opacity: 0;
+        animation: none;
+    }
+
+    .service-card,
+    .button,
+    .menu-toggle span:not(.sr-only) {
+        transition: none;
+    }
+
+    .service-card:hover,
+    .service-card:focus-within,
+    .button:hover,
+    .button:focus-visible {
+        transform: none;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,117 +1,200 @@
-let currentSlide = 0;
+const yearSpan = document.getElementById("current-year");
+const menuToggle = document.querySelector(".menu-toggle");
+const siteNav = document.getElementById("site-nav");
+const mobileCall = document.querySelector(".mobile-call");
+const quoteForms = document.querySelectorAll("[data-quote-form]");
+const emailCopyLinks = document.querySelectorAll("[data-copy-email]");
+const languageSwitches = document.querySelectorAll(".language-switch");
+const sectionLinks = siteNav ? Array.from(siteNav.querySelectorAll('a[href^="#"]')) : [];
+const sections = sectionLinks
+    .map((link) => document.querySelector(link.getAttribute("href")))
+    .filter((section) => section instanceof HTMLElement);
 
-// Function to show the current slide and update dots
-function showSlide(slides, index) {
-    slides.forEach((slide, i) => {
-        slide.classList.remove('active');
-        if (i === index) {
-            slide.classList.add('active');
-            lazyLoadBackgrounds();
-        }
+if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+}
+
+if (menuToggle && siteNav) {
+    menuToggle.addEventListener("click", () => {
+        const isOpen = siteNav.classList.toggle("is-open");
+        menuToggle.setAttribute("aria-expanded", String(isOpen));
     });
-    updateSubheader(index);
-    updateURL();
-    updateDots();
-}
 
-// Function to update the URL with the current slide index
-function updateURL() {
-    const baseURL = window.location.href.split('?')[0];
-    const newURL = `${baseURL}?currentSlide=${currentSlide}`;
-    history.replaceState(null, '', newURL);
-}
-
-// Function to update the active dot
-function updateDots() {
-    const dots = document.querySelectorAll('.dot');
-    dots.forEach((dot, i) => {
-        dot.classList.remove('active');
-        if (i === currentSlide) {
-            dot.classList.add('active');
+    siteNav.addEventListener("click", (event) => {
+        if (event.target instanceof HTMLAnchorElement) {
+            siteNav.classList.remove("is-open");
+            menuToggle.setAttribute("aria-expanded", "false");
         }
     });
 }
 
-// Function to go to a specific slide
-function goToSlide(slideIndex) {
-    currentSlide = slideIndex;
-    const activeSlides = document.querySelectorAll('.carousel-slide');
-    showSlide(activeSlides, currentSlide);
-    updateSubheader(slideIndex);
-    updateLanguageSwitchLinks();
+if (mobileCall) {
+    const updateMobileCall = () => {
+        mobileCall.classList.toggle("is-visible", window.scrollY > 520);
+    };
+
+    updateMobileCall();
+    window.addEventListener("scroll", updateMobileCall, { passive: true });
 }
 
-// Initialize the carousel and footer year with the correct slide
-window.addEventListener('DOMContentLoaded', () => {
-    currentSlide = getCurrentSlide();  // Get the current slide index from URL or default to 0
+languageSwitches.forEach((link) => {
+    link.addEventListener("click", () => {
+        const language = link.getAttribute("lang");
+        if (language !== "en" && language !== "fr") {
+            return;
+        }
 
-    let activeSlides = document.querySelectorAll('.carousel-slide');
-    
-    showSlide(activeSlides, currentSlide);
-    updateSubheader(currentSlide);
-    updateLanguageSwitchLinks();
-    updateDots();
+        try {
+            localStorage.setItem("qualitech-language", language);
+        } catch {
+            // The link still works when storage is unavailable.
+        }
 
-    // Set current year in the footer
-    const yearSpan = document.getElementById('current-year');
-    const currentYear = new Date().getFullYear();
-    yearSpan.textContent = currentYear;
+        const target = new URL(link.getAttribute("href"), window.location.href);
+        target.search = window.location.search;
+        target.hash = window.location.hash;
+        link.href = target.toString();
+    });
 });
 
+let copyToastTimer;
 
-
-// Function to get the current slide index from the URL
-function getCurrentSlide() {
-    const params = new URLSearchParams(window.location.search);
-    const slideIndex = params.get('currentSlide');
-    return slideIndex ? parseInt(slideIndex) : 0;
-}
-
-// Function to show the next slide
-function nextSlide() {
-    const activeSlides = document.querySelectorAll('.carousel-slide');
-    currentSlide = (currentSlide + 1) % activeSlides.length;
-    showSlide(activeSlides, currentSlide);
-    updateLanguageSwitchLinks();
-}
-
-// Function to show the previous slide
-function prevSlide() {
-    const activeSlides = document.querySelectorAll('.carousel-slide');
-    currentSlide = (currentSlide - 1 + activeSlides.length) % activeSlides.length;
-    showSlide(activeSlides, currentSlide);
-    updateLanguageSwitchLinks();
-}
-
-// Function to update the subheader highlight
-function updateSubheader(slideIndex) {
-    const subheaderItems = document.querySelectorAll('.subheader-item');
-    subheaderItems.forEach((item, index) => {
-        item.classList.toggle('active', index === slideIndex);
-    });
-}
-
-// Function to update the language switch links
-function updateLanguageSwitchLinks() {
-    const switchToEnglish = document.getElementById('switch-to-en');
-    const switchToFrench = document.getElementById('switch-to-fr');
-
-    if (switchToEnglish) {
-        switchToEnglish.href = `index-en.html?currentSlide=${currentSlide}`;
+const showCopyToast = (message) => {
+    let toast = document.querySelector("[data-copy-toast]");
+    if (!(toast instanceof HTMLElement)) {
+        toast = document.createElement("div");
+        toast.className = "copy-toast";
+        toast.setAttribute("data-copy-toast", "");
+        toast.setAttribute("role", "status");
+        toast.setAttribute("aria-live", "polite");
+        document.body.appendChild(toast);
     }
-    if (switchToFrench) {
-        switchToFrench.href = `index-fr.html?currentSlide=${currentSlide}`;
+
+    toast.textContent = message;
+    toast.classList.remove("is-visible");
+    window.requestAnimationFrame(() => toast.classList.add("is-visible"));
+    window.clearTimeout(copyToastTimer);
+    copyToastTimer = window.setTimeout(() => {
+        toast.classList.remove("is-visible");
+    }, 2400);
+};
+
+const copyText = async (text) => {
+    if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
     }
-}
 
-// Function to lazy load background images
-function lazyLoadBackgrounds() {
-    const lazyBackgrounds = document.querySelectorAll('.carousel-slide');
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    textArea.setAttribute("readonly", "");
+    textArea.style.position = "fixed";
+    textArea.style.opacity = "0";
+    document.body.appendChild(textArea);
+    textArea.select();
+    const copied = document.execCommand("copy");
+    textArea.remove();
+    if (!copied) {
+        throw new Error("Copy command was not accepted");
+    }
+};
 
-    lazyBackgrounds.forEach(function(lazyBackground) {
-        if (!lazyBackground.style.backgroundImage) {
-            // Apply the background image from data-bg
-            lazyBackground.style.backgroundImage = 'url(' + lazyBackground.dataset.bg + ')';
+emailCopyLinks.forEach((link) => {
+    link.addEventListener("click", async (event) => {
+        const email = link.getAttribute("data-copy-email");
+        if (!email) {
+            return;
+        }
+
+        event.preventDefault();
+        try {
+            await copyText(email);
+            showCopyToast(link.getAttribute("data-copy-success") || "Email address copied");
+        } catch {
+            showCopyToast(link.getAttribute("data-copy-failure") || "Unable to copy; opening your email application.");
+            window.setTimeout(() => {
+                window.location.href = link.href;
+            }, 500);
         }
     });
+});
+
+quoteForms.forEach((form) => {
+    form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!(form instanceof HTMLFormElement) || !form.reportValidity()) {
+            return;
+        }
+
+        const fields = Array.from(form.querySelectorAll("[data-field-label]"));
+        const messageLines = fields.flatMap((field) => {
+            if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement || field instanceof HTMLTextAreaElement)) {
+                return [];
+            }
+
+            const value = field.value.trim();
+            const label = field.getAttribute("data-field-label");
+            return value && label ? [`${label}: ${value}`] : [];
+        });
+        const subject = form.getAttribute("data-subject") || "Qualitech website request";
+        const status = form.querySelector("[data-form-status]");
+        const readyMessage = form.getAttribute("data-ready-message");
+        const mailto = `mailto:info@qualitechelectricite.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(messageLines.join("\n\n"))}`;
+
+        if (status instanceof HTMLElement && readyMessage) {
+            status.textContent = readyMessage;
+        }
+        window.location.href = mailto;
+    });
+});
+
+if (sectionLinks.length && sections.length) {
+    const setActiveSection = (sectionId) => {
+        sectionLinks.forEach((link) => {
+            if (link.getAttribute("href") === `#${sectionId}`) {
+                link.setAttribute("aria-current", "location");
+            } else {
+                link.removeAttribute("aria-current");
+            }
+        });
+    };
+
+    if ("IntersectionObserver" in window) {
+        const visibleSections = new Set();
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    visibleSections.add(entry.target.id);
+                } else {
+                    visibleSections.delete(entry.target.id);
+                }
+            });
+
+            let activeSection;
+            for (let index = sections.length - 1; index >= 0; index -= 1) {
+                if (visibleSections.has(sections[index].id)) {
+                    activeSection = sections[index];
+                    break;
+                }
+            }
+            setActiveSection(activeSection ? activeSection.id : "");
+        }, {
+            rootMargin: "-30% 0px -40% 0px",
+            threshold: 0,
+        });
+
+        sections.forEach((section) => observer.observe(section));
+    } else {
+        const updateActiveSection = () => {
+            const marker = window.innerHeight * 0.4;
+            const activeSection = sections.find((section) => {
+                const bounds = section.getBoundingClientRect();
+                return bounds.top <= marker && bounds.bottom >= marker;
+            });
+            setActiveSection(activeSection ? activeSection.id : "");
+        };
+
+        updateActiveSection();
+        window.addEventListener("scroll", updateActiveSection, { passive: true });
+    }
 }

--- a/index-en.html
+++ b/index-en.html
@@ -1,129 +1,306 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-CA">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Qualitech Électricité Inc. provides professional residential, commercial, and automation electrical services in Montreal. Contact us today for quality electrical solutions.">
-    <title>Qualitech Électricité Inc. - English</title>
-    <link rel="stylesheet" href="assets/css/styles.css">
+    <meta name="theme-color" content="#F5F5F2">
+    <meta name="description" content="Qualitech Électricité Inc. provides residential, commercial and industrial electrical services in Saint-Jean-sur-Richelieu, the South Shore and Greater Montreal.">
+    <meta name="robots" content="index, follow">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Qualitech Électricité Inc.">
+    <meta property="og:locale" content="en_CA">
+    <meta property="og:locale:alternate" content="fr_CA">
+    <meta property="og:title" content="Residential, Commercial &amp; Industrial Electrician | Qualitech">
+    <meta property="og:description" content="Residential, commercial and industrial electrical services, including three-phase power, machinery connections, motor controls, EV chargers and automation.">
+    <meta property="og:url" content="https://qualitechelectricite.com/index-en.html">
+    <meta property="og:image" content="https://qualitechelectricite.com/assets/images/residential.webp">
+    <meta property="og:image:alt" content="Qualitech Électricité residential, commercial and industrial electrical services">
+    <meta property="og:image:width" content="612">
+    <meta property="og:image:height" content="408">
+    <meta property="og:image:type" content="image/webp">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Residential, Commercial &amp; Industrial Electrician | Qualitech">
+    <meta name="twitter:description" content="Three-phase power, machinery connections, motor controls, EV chargers, panels and automation in Greater Montreal and the South Shore.">
+    <meta name="twitter:image" content="https://qualitechelectricite.com/assets/images/residential.webp">
+    <meta name="twitter:image:alt" content="Qualitech Électricité residential, commercial and industrial electrical services">
+    <title>Residential, Commercial &amp; Industrial Electrician | Qualitech</title>
+    <link rel="canonical" href="https://qualitechelectricite.com/index-en.html">
+    <link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html">
+    <link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/">
+    <link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/">
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260719h">
     <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Electrician",
+        "@id": "https://qualitechelectricite.com/#business",
         "name": "Qualitech Électricité Inc.",
-        "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Greater Montreal",
-        "addressRegion": "QC",
-        "postalCode": "J3B 8V9",
-        "addressCountry": "CA"
-        },
-        "contactPoint": {
-        "@type": "ContactPoint",
+        "url": "https://qualitechelectricite.com/",
+        "image": "https://qualitechelectricite.com/assets/images/QE%20Logo.webp",
+        "logo": "https://qualitechelectricite.com/assets/images/QE%20Logo.webp",
         "telephone": "+1-514-806-9323",
-        "contactType": "Customer Service"
+        "email": "info@qualitechelectricite.com",
+        "priceRange": "$$",
+        "sameAs": ["https://www.google.com/maps/place/?q=place_id:ChIJqQRrBgHz6WcRfIX0O20m8-k"],
+        "description": "Residential, commercial and industrial electrical contractor serving Saint-Jean-sur-Richelieu, the South Shore and Greater Montreal.",
+        "identifier": {
+            "@type": "PropertyValue",
+            "propertyID": "RBQ",
+            "value": "5811-4398-01"
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Saint-Jean-sur-Richelieu",
+            "addressRegion": "QC",
+            "addressCountry": "CA"
+        },
+        "areaServed": "Greater Montreal and surrounding areas",
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Electrical services",
+            "itemListElement": [
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Residential electrical services"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Commercial electrical services"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Industrial electrical services"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "EV charger installation"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Electrical panel upgrades"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Three-phase power and machinery connections"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Motor controls and industrial automation"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Preventive maintenance and troubleshooting"}}
+            ]
         }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "Do you install EV chargers?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes. Qualitech can assess panel capacity, wiring requirements, charger location, and installation needs for home or commercial EV charging."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Can you upgrade an electrical panel?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes. Panel upgrades, added circuits, and modernization work are available for residential, commercial, and industrial projects."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Do you provide industrial electrical services?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes. Industrial services include three-phase power, machinery connections, motor controls, industrial automation, preventive maintenance, and troubleshooting."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "How do I request a quote?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Call 514 806 9323 or email info@qualitechelectricite.com with the location, service needed, and any photos that help explain the work."
+                }
+            }
+        ]
     }
     </script>
 </head>
 
 <body>
-    <header>
-        <img src="assets/images/QE Logo.webp" alt="Qualitech Électricité Inc. Logo">
+    <header class="site-header">
+        <a class="brand" href="/" aria-label="Qualitech Electricite home">
+            <img src="assets/images/QE Logo.webp" alt="Qualitech Électricité Inc. logo" width="1200" height="200">
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+        <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="#services">Services</a>
+            <a href="#areas">Service areas</a>
+            <a href="#reviews">Reviews</a>
+            <a href="#faq">FAQ</a>
+            <a href="#contact">Contact</a>
+            <a class="nav-cta" href="tel:+15148069323">Call now</a>
+            <a class="language-switch" href="index.html" lang="fr" hreflang="fr-CA" aria-label="Voir le site en français"><span class="language-long">Français</span><span class="language-short" aria-hidden="true">FR</span></a>
+        </nav>
     </header>
 
     <main>
-        <div class="subheader-panel">
-            <div class="subheader-items-container">
-                <span class="subheader-item" onclick="goToSlide(0)" data-full-text="Residential">Residential</span>
-                <span class="subheader-item" onclick="goToSlide(1)" data-full-text="Commercial">Commercial</span>
-                <span class="subheader-item" onclick="goToSlide(2)" data-full-text="Automation">Automation</span>
-            </div>
-            <div class="language-switch">
-                <a href="index-fr.html" id="switch-to-fr" data-long-text="Français" data-short-text="Fr"></a>
-            </div>
-        </div>
-        
-        <div class="carousel-container">
-            <!-- Residential Slide -->
-            <div class="carousel-slide" id="slide-residential-en" data-bg="assets/images/residential.webp">
-                <div class="carousel-header">
-                    Residential Electrical Services
+        <section class="hero">
+            <div class="hero-media" aria-hidden="true"></div>
+            <div class="hero-content">
+                <p class="eyebrow">Electrician in Saint-Jean-sur-Richelieu</p>
+                <h1>Electrical work for homes, businesses and industry.</h1>
+                <p class="hero-copy">Qualitech Électricité Inc. serves Saint-Jean-sur-Richelieu, the South Shore, and Greater Montreal with EV chargers, panel upgrades, three-phase power, machinery connections, and automation.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="tel:+15148069323">Call 514 806 9323</a>
+                    <a class="button secondary" href="#quote" hidden>Request a quote</a>
                 </div>
-                <div class="carousel-content">
-                    <p>We specialize in residential electrical services, offering everything from minor repairs to complete system installations.</p>
-                    <ul>
-                        <li>Lighting installation and upgrades</li>
-                        <li>Electrical panel upgrades</li>
-                        <li>Wiring and rewiring services</li>
-                        <li>Home security systems</li>
-                        <li>EV charger installations</li>
-                    </ul>
-                </div>
+                <dl class="trust-list">
+                    <div><dt>Based in</dt><dd>Saint-Jean-sur-Richelieu</dd></div>
+                    <div><dt>Service</dt><dd>Residential, commercial and industrial</dd></div>
+                    <div><dt>Specialties</dt><dd>Panels, EV chargers, industrial controls</dd></div>
+                </dl>
             </div>
+        </section>
 
-            <!-- Commercial Slide -->
-            <div class="carousel-slide" id="slide-commercial-en" data-bg="assets/images/commercial.webp">
-                <div class="carousel-header">
-                    Commercial Electrical Services
-                </div>
-                <div class="carousel-content">
-                    <p>Our expert team offers reliable electrical solutions for businesses, ensuring safety and efficiency.</p>
-                    <ul>
-                        <li>Electrical system design and installation</li>
-                        <li>Office and retail lighting solutions</li>
-                        <li>Surge protection and backup power</li>
-                        <li>Safety and security systems</li>
-                        <li>Regular maintenance contracts</li>
-                    </ul>
-                </div>
+        <section class="section intro" aria-labelledby="intro-title">
+            <div class="section-header">
+                <p class="eyebrow">Local electrical contractor</p>
+                <h2 id="intro-title">Clear advice, careful installation, and reliable follow-through.</h2>
             </div>
+            <div class="intro-copy">
+                <p>Whether you are renovating a home, preparing a commercial or industrial facility, connecting machinery, or modernizing power and controls, Qualitech supports planned projects, preventive maintenance, and troubleshooting.</p>
+                <p>Customers get clear communication, direct contact, and service details before the first call.</p>
+            </div>
+        </section>
 
-            <!-- Automation Slide -->
-            <div class="carousel-slide" id="slide-automation-en" data-bg="assets/images/automation.webp">
-                <div class="carousel-header">
-                    Automation Solutions
-                </div>
-                <div class="carousel-content">
-                    <p>Enhance your space with our automation services, bringing advanced technology to your home or business.</p>
-                    <ul>
-                        <li>Smart lighting control systems</li>
-                        <li>Home and office climate control</li>
-                        <li>Remote access security systems</li>
-                        <li>Integrated sound and entertainment systems</li>
-                        <li>Energy management solutions</li>
-                    </ul>
-                </div>
+        <section class="section services" id="services" aria-labelledby="services-title">
+            <div class="section-header">
+                <p class="eyebrow">Electrical services</p>
+                <h2 id="services-title">Support for everyday service calls and planned upgrades.</h2>
             </div>
-
-            <div class="carousel-nav">
-                <button onclick="prevSlide()" aria-label="Previous Slide">&#10094;</button>
-                <button onclick="nextSlide()" aria-label="Next Slide">&#10095;</button>
+            <div class="service-grid">
+                <article class="service-card">
+                    <img src="assets/images/residential.webp" alt="Residential electrical wiring work" width="640" height="420" loading="lazy">
+                    <div><h3>Residential electrical</h3><p>Repairs, new circuits, lighting, rewiring, safety improvements, and electrical work for renovations.</p></div>
+                </article>
+                <article class="service-card">
+                    <img src="assets/images/commercial.webp" alt="Commercial and industrial electrical panels and controls" width="640" height="420" loading="lazy">
+                    <div><h3>Commercial and industrial electrical</h3><p>Electrical installations, lighting, three-phase power, machinery connections, preventive maintenance, and troubleshooting.</p></div>
+                </article>
+                <article class="service-card">
+                    <img src="assets/images/automation.webp" alt="Industrial automation and motor control equipment" width="640" height="420" loading="lazy">
+                    <div><h3>Automation and controls</h3><p>Motor controls, industrial automation, smart lighting, climate controls, remote access, and energy management.</p></div>
+                </article>
             </div>
-        </div> 
-        <div class="carousel-dots" id="carousel-dots">
-            <span class="dot" onclick="goToSlide(0)"></span>
-            <span class="dot" onclick="goToSlide(1)"></span>
-            <span class="dot" onclick="goToSlide(2)"></span>
-        </div>
-    </main>
-    <section id="contact">
-        <h2>Contact Us</h2>
-        <address>
-            <ul>
-                <li>Phone: <a href="tel:+15148069323">514 806 9323</a></li>
-                <li>Email: <a href="info@qualitechelectricite.com">info@qualitechelectricite.com</a></li>
+            <article class="industrial-callout" aria-labelledby="industrial-title">
+                <div><p class="eyebrow">Industrial capability</p><h3 id="industrial-title">Power and controls for industrial operations.</h3></div>
+                <p>Qualitech connects three-phase equipment and machinery, installs motor controls and automation, and supports facilities with preventive maintenance and electrical troubleshooting.</p>
+            </article>
+            <ul class="feature-list" aria-label="Common requested services">
+                <li>Panel upgrades</li><li>EV charger installation</li><li>Three-phase power</li><li>Machinery connections</li><li>Motor controls</li><li>Industrial automation</li><li>Preventive maintenance</li><li>Troubleshooting</li>
             </ul>
-        </address>
-    </section>
+        </section>
 
-    <footer>
-        <p>&copy; <span id="current-year"></span> Qualitech Électricité Inc. All rights reserved.</p>
+        <section class="section split service-area" id="areas" aria-labelledby="areas-title">
+            <iframe class="service-area__map" src="https://www.openstreetmap.org/export/embed.html?bbox=-74.10%2C45.20%2C-73.05%2C45.84&amp;layer=mapnik" title="Map of the Greater Montreal service area" loading="lazy" referrerpolicy="no-referrer" tabindex="-1"></iframe>
+            <div class="service-area__content">
+                <p class="eyebrow">Service area</p>
+                <h2 id="areas-title">Serving Greater Montreal and surrounding areas.</h2>
+                <p>Based in Saint-Jean-sur-Richelieu, Qualitech serves residential, commercial, and industrial clients throughout the region.</p>
+            </div>
+            <small class="map-attribution">Map data © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap contributors</a></small>
+        </section>
+
+        <section class="section reviews" id="reviews" aria-labelledby="reviews-title">
+            <div class="review-panel">
+                <p class="eyebrow">Google reviews</p>
+                <h2 id="reviews-title">See what customers are saying on Google.</h2>
+                <p>Selected feedback from customers who reviewed Qualitech on Google.</p>
+                <div class="review-grid">
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 out of 5 stars">★★★★★</div>
+                        <blockquote><p>“Excellent service from start to finish! Punctual, meticulous in every detail, and highly professional.”</p></blockquote>
+                        <figcaption>DENTFIX Débosselage sans peinture</figcaption>
+                    </figure>
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 out of 5 stars">★★★★★</div>
+                        <blockquote><p>“Install was done with care and expertise. Very happy with the results.”</p></blockquote>
+                        <figcaption>Patrick H</figcaption>
+                    </figure>
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 out of 5 stars">★★★★★</div>
+                        <blockquote><p>“Honest, professional, efficient, immediate response for quotation, on time personal service.”</p></blockquote>
+                        <figcaption>Andrii</figcaption>
+                    </figure>
+                </div>
+                <div class="hero-actions">
+                    <a class="button primary" href="https://www.google.com/maps/place/Qualitech+%C3%89lectricit%C3%A9+Inc./@45.2751445,-73.2690391,17z/data=!4m8!3m7!1s0x67e9f301066b04a9:0xe9f3266d3bf4857c!8m2!3d45.2751445!4d-73.2690391!9m1!1b1!16s%2Fg%2F11vyqr8wj1?entry=ttu&amp;hl=en-CA" target="_blank" rel="noopener noreferrer">Read all Google reviews</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section faq" id="faq" aria-labelledby="faq-title">
+            <div class="section-header">
+                <p class="eyebrow">Questions</p>
+                <h2 id="faq-title">Common electrical service questions.</h2>
+            </div>
+            <div class="faq-grid">
+                <article><h3>Do you install EV chargers?</h3><p>Yes. Qualitech can assess panel capacity, wiring requirements, charger location, and installation needs for home or commercial EV charging.</p></article>
+                <article><h3>Can you upgrade an electrical panel?</h3><p>Yes. Panel upgrades, added circuits, and modernization work are available for residential, commercial, and industrial projects.</p></article>
+                <article><h3>Do you provide industrial electrical services?</h3><p>Yes. Industrial services include three-phase power, machinery connections, motor controls, industrial automation, preventive maintenance, and troubleshooting.</p></article>
+                <article><h3>How do I request a quote?</h3><p>Call 514 806 9323 or email info@qualitechelectricite.com with the location, service needed, and any photos that help explain the work.</p></article>
+            </div>
+        </section>
+
+        <section class="section quote-section" id="quote" aria-labelledby="quote-title" hidden>
+            <div class="quote-intro">
+                <p class="eyebrow">Quote request</p>
+                <h2 id="quote-title">Tell us about your electrical project.</h2>
+                <p>Complete the details below. Your email application will open with a prepared message that you can review, complete, and send to Qualitech.</p>
+                <p class="form-note">This website does not store your information. You can attach photos directly to the email before sending it.</p>
+            </div>
+            <form class="quote-form" action="mailto:info@qualitechelectricite.com" method="post" enctype="text/plain" data-quote-form data-subject="Quote request — Qualitech website" data-ready-message="Your request is ready. Check your email application to send it.">
+                <div class="form-grid">
+                    <label>Full name <span aria-hidden="true">*</span><input type="text" name="name" autocomplete="name" maxlength="100" required data-field-label="Name"></label>
+                    <label>Email <span aria-hidden="true">*</span><input type="email" name="email" autocomplete="email" maxlength="254" required data-field-label="Email"></label>
+                    <label>Phone<input type="tel" name="phone" autocomplete="tel" inputmode="tel" maxlength="40" data-field-label="Phone"></label>
+                    <label>Project city <span aria-hidden="true">*</span><input type="text" name="city" autocomplete="address-level2" maxlength="100" required data-field-label="Project city"></label>
+                    <label class="form-span">Service needed <span aria-hidden="true">*</span>
+                        <select name="service" required data-field-label="Service needed">
+                            <option value="">Select a service</option>
+                            <option>Residential</option>
+                            <option>Commercial</option>
+                            <option>Industrial</option>
+                            <option>EV charger</option>
+                            <option>Electrical panel</option>
+                            <option>Automation and controls</option>
+                            <option>Troubleshooting</option>
+                            <option>Other</option>
+                        </select>
+                    </label>
+                    <label class="form-span">Describe the work <span aria-hidden="true">*</span><textarea name="details" rows="6" maxlength="2000" required data-field-label="Work description" placeholder="Describe the problem, installation, or upgrade you need."></textarea></label>
+                    <label class="form-span">Preferred timing<input type="text" name="timing" maxlength="160" data-field-label="Preferred timing" placeholder="For example: as soon as possible, this month, or a specific date"></label>
+                </div>
+                <button class="button primary" type="submit">Prepare my request</button>
+                <p class="form-status" data-form-status aria-live="polite"></p>
+            </form>
+        </section>
+
+        <section class="contact-section" id="contact" aria-labelledby="contact-title">
+            <div>
+                <p class="eyebrow">Contact</p>
+                <h2 id="contact-title">Talk to an electrician.</h2>
+                <p>Share the project location, the type of work, and the ideal timing. Photos of the panel or installation area can help with an initial estimate.</p>
+            </div>
+            <address class="contact-card">
+                <a href="tel:+15148069323">514 806 9323</a>
+                <a class="email-copy" href="mailto:info@qualitechelectricite.com" data-copy-email="info@qualitechelectricite.com" data-copy-success="Email address copied" data-copy-failure="Unable to copy; opening your email application."><span>info@qualitechelectricite.com</span><small>Click to copy</small></a>
+                <span>Based in Saint-Jean-sur-Richelieu, QC</span>
+            </address>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year">2026</span> Qualitech Électricité Inc. All rights reserved.</p>
+        <p class="footer-rbq">RBQ: 5811-4398-01</p>
     </footer>
 
-    <script src="assets/js/main.js" defer></script>
+    <a class="mobile-call" href="tel:+15148069323">Call 514 806 9323</a>
+    <script src="assets/js/main.js?v=20260719g" defer></script>
 </body>
 
 </html>

--- a/index-fr.html
+++ b/index-fr.html
@@ -1,129 +1,306 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr-CA">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Qualitech Électricité Inc. fournit des services électriques professionnels résidentiels, commerciaux et d'automatisation à Montréal. Contactez-nous dès aujourd'hui pour des solutions électriques de qualité.">
-    <title>Qualitech Électricité Inc. - Français</title>
-    <link rel="stylesheet" href="assets/css/styles.css">
+    <meta name="theme-color" content="#F5F5F2">
+    <meta name="description" content="Qualitech Électricité Inc. offre des services électriques résidentiels, commerciaux et industriels à Saint-Jean-sur-Richelieu, sur la Rive-Sud et dans le Grand Montréal.">
+    <meta name="robots" content="noindex, follow">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Qualitech Électricité Inc.">
+    <meta property="og:locale" content="fr_CA">
+    <meta property="og:locale:alternate" content="en_CA">
+    <meta property="og:title" content="Électricien résidentiel, commercial et industriel | Qualitech">
+    <meta property="og:description" content="Services électriques résidentiels, commerciaux et industriels : alimentation triphasée, raccordement de machinerie, commandes de moteurs, bornes et automatisation.">
+    <meta property="og:url" content="https://qualitechelectricite.com/">
+    <meta property="og:image" content="https://qualitechelectricite.com/assets/images/residential.webp">
+    <meta property="og:image:alt" content="Services électriques résidentiels, commerciaux et industriels de Qualitech Électricité">
+    <meta property="og:image:width" content="612">
+    <meta property="og:image:height" content="408">
+    <meta property="og:image:type" content="image/webp">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Électricien résidentiel, commercial et industriel | Qualitech">
+    <meta name="twitter:description" content="Triphasé, raccordement de machinerie, commandes de moteurs, bornes, panneaux et automatisation sur la Rive-Sud et dans le Grand Montréal.">
+    <meta name="twitter:image" content="https://qualitechelectricite.com/assets/images/residential.webp">
+    <meta name="twitter:image:alt" content="Services électriques résidentiels, commerciaux et industriels de Qualitech Électricité">
+    <title>Électricien résidentiel, commercial et industriel | Qualitech</title>
+    <link rel="canonical" href="https://qualitechelectricite.com/">
+    <link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html">
+    <link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/">
+    <link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/">
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260719h">
     <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Electrician",
+        "@id": "https://qualitechelectricite.com/#business",
         "name": "Qualitech Électricité Inc.",
-        "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Grand Montréal",
-        "addressRegion": "QC",
-        "postalCode": "J3B 8V9",
-        "addressCountry": "CA"
-        },
-        "contactPoint": {
-        "@type": "ContactPoint",
+        "url": "https://qualitechelectricite.com/",
+        "image": "https://qualitechelectricite.com/assets/images/QE%20Logo.webp",
+        "logo": "https://qualitechelectricite.com/assets/images/QE%20Logo.webp",
         "telephone": "+1-514-806-9323",
-        "contactType": "Service clientèle"
+        "email": "info@qualitechelectricite.com",
+        "priceRange": "$$",
+        "sameAs": ["https://www.google.com/maps/place/?q=place_id:ChIJqQRrBgHz6WcRfIX0O20m8-k"],
+        "description": "Entrepreneur en électricité résidentielle, commerciale et industrielle desservant Saint-Jean-sur-Richelieu, la Rive-Sud et le Grand Montréal.",
+        "identifier": {
+            "@type": "PropertyValue",
+            "propertyID": "RBQ",
+            "value": "5811-4398-01"
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Saint-Jean-sur-Richelieu",
+            "addressRegion": "QC",
+            "addressCountry": "CA"
+        },
+        "areaServed": "Grand Montréal et environs",
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Services électriques",
+            "itemListElement": [
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Services électriques résidentiels"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Services électriques commerciaux"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Services électriques industriels"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Installation de bornes de recharge"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Mise à niveau de panneaux électriques"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Alimentation triphasée et raccordement de machinerie"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Commandes de moteurs et automatisation industrielle"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Entretien préventif et dépannage"}}
+            ]
         }
     }
     </script>
-        
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "Installez-vous des bornes de recharge?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Oui. Qualitech peut évaluer la capacité du panneau, le câblage, l'emplacement de la borne et les besoins d'installation."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Pouvez-vous moderniser un panneau électrique?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Oui. Les mises à niveau de panneaux, les circuits additionnels et les travaux de modernisation sont offerts pour les projets résidentiels, commerciaux et industriels."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Offrez-vous des services électriques industriels?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Oui. Les services industriels comprennent l'alimentation triphasée, le raccordement de machinerie, les commandes de moteurs, l'automatisation industrielle, l'entretien préventif et le dépannage."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Comment demander une soumission?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Appelez au 514 806 9323 ou envoyez un courriel à info@qualitechelectricite.com avec l'adresse, le type de service et des photos si possible."
+                }
+            }
+        ]
+    }
+    </script>
 </head>
 
 <body>
-    <header>
-        <img src="assets/images/QE Logo.webp" alt="Qualitech Électricité Inc. Logo">
+    <header class="site-header">
+        <a class="brand" href="/" aria-label="Accueil Qualitech Électricité">
+            <img src="assets/images/QE Logo.webp" alt="Logo Qualitech Électricité Inc." width="1200" height="200">
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+        <nav class="site-nav" id="site-nav" aria-label="Navigation principale">
+            <a href="#services">Services</a>
+            <a href="#areas">Territoire</a>
+            <a href="#reviews">Avis</a>
+            <a href="#faq">FAQ</a>
+            <a href="#contact">Contact</a>
+            <a class="nav-cta" href="tel:+15148069323">Appeler</a>
+            <a class="language-switch" href="index-en.html" lang="en" hreflang="en-CA" aria-label="View the site in English"><span class="language-long">English</span><span class="language-short" aria-hidden="true">EN</span></a>
+        </nav>
     </header>
+
     <main>
-        <div class="subheader-panel">
-            <div class="subheader-items-container">
-                <span class="subheader-item" onclick="goToSlide(0)" data-full-text="Résidentiels">Résidentiels</span>
-                <span class="subheader-item" onclick="goToSlide(1)" data-full-text="Commerciaux">Commerciaux</span>
-                <span class="subheader-item" onclick="goToSlide(2)" data-full-text="d'Automatisation">d'Automatisation</span>
+        <section class="hero">
+            <div class="hero-media" aria-hidden="true"></div>
+            <div class="hero-content">
+                <p class="eyebrow">Électricien à Saint-Jean-sur-Richelieu</p>
+                <h1>Travaux électriques résidentiels, commerciaux et industriels.</h1>
+                <p class="hero-copy">Qualitech Électricité Inc. dessert Saint-Jean-sur-Richelieu, la Rive-Sud et le Grand Montréal pour les bornes de recharge, les panneaux, l'alimentation triphasée, le raccordement de machinerie et l'automatisation.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="tel:+15148069323">Appeler 514 806 9323</a>
+                    <a class="button secondary" href="#quote" hidden>Demander une soumission</a>
+                </div>
+                <dl class="trust-list">
+                    <div><dt>Située à</dt><dd>Saint-Jean-sur-Richelieu</dd></div>
+                    <div><dt>Service</dt><dd>Résidentiel, commercial et industriel</dd></div>
+                    <div><dt>Spécialités</dt><dd>Panneaux, bornes, contrôles industriels</dd></div>
+                </dl>
             </div>
-            <div class="language-switch">
-                <a href="index-en.html" id="switch-to-en" data-long-text="English" data-short-text="En"></a>
-            </div>
-        </div>
+        </section>
 
-        <div class="carousel-container">
-            <!-- Residential Slide -->
-            <div class="carousel-slide" id="slide-residential-fr" data-bg="assets/images/residential.webp">
-                <div class="carousel-header">
-                    Services Électriques Résidentiels
-                </div>
-                <div class="carousel-content">
-                    <p>Nous nous spécialisons dans les services électriques résidentiels, offrant tout, des réparations mineures aux installations complètes.</p>
-                    <ul>
-                        <li>Installation et mise à niveau de l'éclairage</li>
-                        <li>Amélioration des panneaux électriques</li>
-                        <li>Services de câblage et de recâblage</li>
-                        <li>Systèmes de sécurité à domicile</li>
-                        <li>Installations de bornes de recharge pour véhicules électriques</li>
-                    </ul>
-                </div>
+        <section class="section intro" aria-labelledby="intro-title">
+            <div class="section-header">
+                <p class="eyebrow">Entrepreneur électricien local</p>
+                <h2 id="intro-title">Des conseils clairs, une installation soignée et un suivi fiable.</h2>
             </div>
+            <div class="intro-copy">
+                <p>Pour une rénovation résidentielle, un espace commercial ou industriel, un raccordement de machinerie ou une modernisation des systèmes électriques et de contrôle, Qualitech réalise des projets planifiés, de l'entretien préventif et du dépannage.</p>
+                <p>Les clients trouvent rapidement les services, les coordonnées et les informations utiles avant le premier appel.</p>
+            </div>
+        </section>
 
-            <!-- Commercial Slide -->
-            <div class="carousel-slide" id="slide-commercial-fr" data-bg="assets/images/commercial.webp">
-                <div class="carousel-header">
-                    Services Électriques Commerciaux
-                </div>
-                <div class="carousel-content">
-                    <p>Notre équipe d'experts offre des solutions électriques fiables pour les entreprises, garantissant sécurité et efficacité.</p>
-                    <ul>
-                        <li>Conception et installation de systèmes électriques</li>
-                        <li>Solutions d'éclairage pour bureaux et commerces</li>
-                        <li>Protection contre les surtensions et alimentation de secours</li>
-                        <li>Systèmes de sécurité</li>
-                        <li>Contrats de maintenance réguliers</li>
-                    </ul>
-                </div>
+        <section class="section services" id="services" aria-labelledby="services-title">
+            <div class="section-header">
+                <p class="eyebrow">Services électriques</p>
+                <h2 id="services-title">Soutien pour les appels de service et les mises à niveau planifiées.</h2>
             </div>
-
-            <!-- Automation Slide -->
-            <div class="carousel-slide" id="slide-automation-fr" data-bg="assets/images/automation.webp">
-                <div class="carousel-header">
-                    Solutions d'Automatisation
-                </div>
-                <div class="carousel-content">
-                    <p>Améliorez votre espace avec nos services d'automatisation, apportant la technologie avancée à votre domicile ou entreprise.</p>
-                    <ul>
-                        <li>Systèmes de contrôle d'éclairage intelligent</li>
-                        <li>Contrôle du climat à domicile et au bureau</li>
-                        <li>Systèmes de sécurité à accès à distance</li>
-                        <li>Systèmes intégrés de son et de divertissement</li>
-                        <li>Solutions de gestion de l'énergie</li>
-                    </ul>
-                </div>
+            <div class="service-grid">
+                <article class="service-card">
+                    <img src="assets/images/residential.webp" alt="Travaux de câblage électrique résidentiel" width="640" height="420" loading="lazy">
+                    <div><h3>Électricité résidentielle</h3><p>Réparations, nouveaux circuits, éclairage, recâblage, améliorations de sécurité et travaux pour rénovations.</p></div>
+                </article>
+                <article class="service-card">
+                    <img src="assets/images/commercial.webp" alt="Panneaux et contrôles électriques commerciaux et industriels" width="640" height="420" loading="lazy">
+                    <div><h3>Électricité commerciale et industrielle</h3><p>Installations électriques, éclairage, alimentation triphasée, raccordement de machinerie, entretien préventif et dépannage.</p></div>
+                </article>
+                <article class="service-card">
+                    <img src="assets/images/automation.webp" alt="Équipement d'automatisation industrielle et de commande de moteurs" width="640" height="420" loading="lazy">
+                    <div><h3>Automatisation et contrôles</h3><p>Commandes de moteurs, automatisation industrielle, éclairage intelligent, contrôle climatique, accès à distance et gestion de l'énergie.</p></div>
+                </article>
             </div>
-
-            <div class="carousel-nav">
-                <button onclick="prevSlide()" aria-label="Previous Slide">&#10094;</button>
-                <button onclick="nextSlide()" aria-label="Next Slide">&#10095;</button>
-            </div>
-        </div>
-        <div class="carousel-dots" id="carousel-dots">
-            <span class="dot" onclick="goToSlide(0)"></span>
-            <span class="dot" onclick="goToSlide(1)"></span>
-            <span class="dot" onclick="goToSlide(2)"></span>
-        </div>
-    </main>
-    <section id="contact">
-        <h2>Contactez-Nous</h2>
-        <address>
-            <ul>
-                <li>Téléphone: <a href="tel:+15148069323">514 806 9323</a></li>
-                <li>Email: <a href="info@qualitechelectricite.com">info@qualitechelectricite.com</a></li>
+            <article class="industrial-callout" aria-labelledby="industrial-title">
+                <div><p class="eyebrow">Capacité industrielle</p><h3 id="industrial-title">Puissance et contrôles pour les opérations industrielles.</h3></div>
+                <p>Qualitech raccorde les équipements triphasés et la machinerie, installe les commandes de moteurs et l'automatisation, et soutient les installations avec l'entretien préventif et le dépannage électrique.</p>
+            </article>
+            <ul class="feature-list" aria-label="Services souvent demandés">
+                <li>Mise à niveau de panneaux</li><li>Bornes de recharge</li><li>Alimentation triphasée</li><li>Raccordement de machinerie</li><li>Commandes de moteurs</li><li>Automatisation industrielle</li><li>Entretien préventif</li><li>Dépannage</li>
             </ul>
-        </address>
-    </section>
+        </section>
 
-    <footer>
-        <p>&copy; <span id="current-year"></span> Qualitech Électricité Inc. Tous droits réservés.</p>
+        <section class="section split service-area" id="areas" aria-labelledby="areas-title">
+            <iframe class="service-area__map" src="https://www.openstreetmap.org/export/embed.html?bbox=-74.10%2C45.20%2C-73.05%2C45.84&amp;layer=mapnik" title="Carte du territoire desservi dans le Grand Montréal" loading="lazy" referrerpolicy="no-referrer" tabindex="-1"></iframe>
+            <div class="service-area__content">
+                <p class="eyebrow">Territoire</p>
+                <h2 id="areas-title">Au service du Grand Montréal et des environs.</h2>
+                <p>Basée à Saint-Jean-sur-Richelieu, Qualitech dessert une clientèle résidentielle, commerciale et industrielle dans toute la région.</p>
+            </div>
+            <small class="map-attribution">Données cartographiques © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">contributeurs OpenStreetMap</a></small>
+        </section>
+
+        <section class="section reviews" id="reviews" aria-labelledby="reviews-title">
+            <div class="review-panel">
+                <p class="eyebrow">Avis Google</p>
+                <h2 id="reviews-title">Consultez les avis clients sur Google.</h2>
+                <p>Quelques commentaires de clients ayant évalué Qualitech sur Google.</p>
+                <div class="review-grid">
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 étoiles sur 5">★★★★★</div>
+                        <blockquote><p>« On a eu une solide urgence un samedi matin. On avait besoin d'un électricien immédiatement. [&hellip;] »</p></blockquote>
+                        <figcaption>Julie Couture</figcaption>
+                    </figure>
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 étoiles sur 5">★★★★★</div>
+                        <blockquote><p>« Yuri est ponctuel, il a tout fait rapidement, clairement, en toute confiance. »</p></blockquote>
+                        <figcaption>Vladyslav Kazantsev</figcaption>
+                    </figure>
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 étoiles sur 5">★★★★★</div>
+                        <blockquote><p>« Excellent service, toujours très professionnel et agréable!! »</p></blockquote>
+                        <figcaption>Tatiana Climenco</figcaption>
+                    </figure>
+                </div>
+                <div class="hero-actions">
+                    <a class="button primary" href="https://www.google.com/maps/place/Qualitech+%C3%89lectricit%C3%A9+Inc./@45.2751445,-73.2690391,17z/data=!4m8!3m7!1s0x67e9f301066b04a9:0xe9f3266d3bf4857c!8m2!3d45.2751445!4d-73.2690391!9m1!1b1!16s%2Fg%2F11vyqr8wj1?entry=ttu&amp;hl=fr-CA" target="_blank" rel="noopener noreferrer">Lire tous les avis Google</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section faq" id="faq" aria-labelledby="faq-title">
+            <div class="section-header">
+                <p class="eyebrow">Questions</p>
+                <h2 id="faq-title">Questions fréquentes sur les services électriques.</h2>
+            </div>
+            <div class="faq-grid">
+                <article><h3>Installez-vous des bornes de recharge?</h3><p>Oui. Qualitech peut évaluer la capacité du panneau, le câblage, l'emplacement de la borne et les besoins d'installation.</p></article>
+                <article><h3>Pouvez-vous moderniser un panneau électrique?</h3><p>Oui. Les mises à niveau de panneaux, les circuits additionnels et les travaux de modernisation sont offerts pour les projets résidentiels, commerciaux et industriels.</p></article>
+                <article><h3>Offrez-vous des services électriques industriels?</h3><p>Oui. Les services industriels comprennent l'alimentation triphasée, le raccordement de machinerie, les commandes de moteurs, l'automatisation industrielle, l'entretien préventif et le dépannage.</p></article>
+                <article><h3>Comment demander une soumission?</h3><p>Appelez au 514 806 9323 ou envoyez un courriel à info@qualitechelectricite.com avec l'adresse, le type de service et des photos si possible.</p></article>
+            </div>
+        </section>
+
+        <section class="section quote-section" id="quote" aria-labelledby="quote-title" hidden>
+            <div class="quote-intro">
+                <p class="eyebrow">Demande de soumission</p>
+                <h2 id="quote-title">Parlez-nous de votre projet électrique.</h2>
+                <p>Remplissez les renseignements ci-dessous. Votre application courriel s’ouvrira avec un message préparé que vous pourrez vérifier, compléter et envoyer à Qualitech.</p>
+                <p class="form-note">Aucun renseignement n’est enregistré par ce site. Vous pourrez joindre des photos directement dans votre courriel avant de l’envoyer.</p>
+            </div>
+            <form class="quote-form" action="mailto:info@qualitechelectricite.com" method="post" enctype="text/plain" data-quote-form data-subject="Demande de soumission — site Web Qualitech" data-ready-message="Votre demande a été préparée. Vérifiez votre application courriel pour l’envoyer.">
+                <div class="form-grid">
+                    <label>Nom complet <span aria-hidden="true">*</span><input type="text" name="name" autocomplete="name" maxlength="100" required data-field-label="Nom"></label>
+                    <label>Courriel <span aria-hidden="true">*</span><input type="email" name="email" autocomplete="email" maxlength="254" required data-field-label="Courriel"></label>
+                    <label>Téléphone<input type="tel" name="phone" autocomplete="tel" inputmode="tel" maxlength="40" data-field-label="Téléphone"></label>
+                    <label>Ville du projet <span aria-hidden="true">*</span><input type="text" name="city" autocomplete="address-level2" maxlength="100" required data-field-label="Ville du projet"></label>
+                    <label class="form-span">Type de service <span aria-hidden="true">*</span>
+                        <select name="service" required data-field-label="Type de service">
+                            <option value="">Sélectionnez un service</option>
+                            <option>Résidentiel</option>
+                            <option>Commercial</option>
+                            <option>Industriel</option>
+                            <option>Borne de recharge</option>
+                            <option>Panneau électrique</option>
+                            <option>Automatisation et contrôles</option>
+                            <option>Dépannage</option>
+                            <option>Autre</option>
+                        </select>
+                    </label>
+                    <label class="form-span">Décrivez les travaux <span aria-hidden="true">*</span><textarea name="details" rows="6" maxlength="2000" required data-field-label="Description des travaux" placeholder="Décrivez le problème, l’installation ou la mise à niveau souhaitée."></textarea></label>
+                    <label class="form-span">Échéancier souhaité<input type="text" name="timing" maxlength="160" data-field-label="Échéancier souhaité" placeholder="Par exemple : dès que possible, ce mois-ci ou une date précise"></label>
+                </div>
+                <button class="button primary" type="submit">Préparer ma demande</button>
+                <p class="form-status" data-form-status aria-live="polite"></p>
+            </form>
+        </section>
+
+        <section class="contact-section" id="contact" aria-labelledby="contact-title">
+            <div>
+                <p class="eyebrow">Contact</p>
+                <h2 id="contact-title">Parlez à un électricien.</h2>
+                <p>Indiquez l'emplacement du projet, le type de travaux et le moment souhaité. Des photos du panneau ou de la zone d'installation peuvent aider à préparer une première estimation.</p>
+            </div>
+            <address class="contact-card">
+                <a href="tel:+15148069323">514 806 9323</a>
+                <a class="email-copy" href="mailto:info@qualitechelectricite.com" data-copy-email="info@qualitechelectricite.com" data-copy-success="Adresse courriel copiée" data-copy-failure="Impossible de copier; ouverture de votre application courriel."><span>info@qualitechelectricite.com</span><small>Cliquer pour copier</small></a>
+                <span>Basée à Saint-Jean-sur-Richelieu, QC</span>
+            </address>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year">2026</span> Qualitech Électricité Inc. Tous droits réservés.</p>
+        <p class="footer-rbq">RBQ&nbsp;: 5811-4398-01</p>
     </footer>
 
-    <script src="assets/js/main.js" defer></script>
+    <a class="mobile-call" href="tel:+15148069323">Appeler 514 806 9323</a>
+    <script src="assets/js/main.js?v=20260719g" defer></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -1,25 +1,315 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr-CA">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Qualitech Électricité Inc.</title>
-    <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
+    <meta name="theme-color" content="#F5F5F2">
+    <meta name="description" content="Qualitech Électricité Inc. offre des services électriques résidentiels, commerciaux et industriels à Saint-Jean-sur-Richelieu, sur la Rive-Sud et dans le Grand Montréal.">
+    <meta name="robots" content="index, follow">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Qualitech Électricité Inc.">
+    <meta property="og:locale" content="fr_CA">
+    <meta property="og:locale:alternate" content="en_CA">
+    <meta property="og:title" content="Électricien résidentiel, commercial et industriel | Qualitech">
+    <meta property="og:description" content="Services électriques résidentiels, commerciaux et industriels : alimentation triphasée, raccordement de machinerie, commandes de moteurs, bornes et automatisation.">
+    <meta property="og:url" content="https://qualitechelectricite.com/">
+    <meta property="og:image" content="https://qualitechelectricite.com/assets/images/residential.webp">
+    <meta property="og:image:alt" content="Services électriques résidentiels, commerciaux et industriels de Qualitech Électricité">
+    <meta property="og:image:width" content="612">
+    <meta property="og:image:height" content="408">
+    <meta property="og:image:type" content="image/webp">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Électricien résidentiel, commercial et industriel | Qualitech">
+    <meta name="twitter:description" content="Triphasé, raccordement de machinerie, commandes de moteurs, bornes, panneaux et automatisation sur la Rive-Sud et dans le Grand Montréal.">
+    <meta name="twitter:image" content="https://qualitechelectricite.com/assets/images/residential.webp">
+    <meta name="twitter:image:alt" content="Services électriques résidentiels, commerciaux et industriels de Qualitech Électricité">
+    <title>Électricien résidentiel, commercial et industriel | Qualitech</title>
+    <link rel="canonical" href="https://qualitechelectricite.com/">
+    <link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html">
+    <link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/">
+    <link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/">
     <script>
-        // Detect browser language
-        const userLang = navigator.language || navigator.userLanguage;
-
-        // Redirect based on browser language
-        if (userLang.startsWith('fr')) {
-            window.location.href = 'index-fr.html';
-        } else {
-            window.location.href = 'index-en.html';
+    try {
+        if (localStorage.getItem("qualitech-language") === "en") {
+            window.location.replace(`index-en.html${window.location.search}${window.location.hash}`);
         }
+    } catch {
+        // Storage can be unavailable in privacy-restricted browsing modes.
+    }
+    </script>
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260719h">
+    <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Electrician",
+        "@id": "https://qualitechelectricite.com/#business",
+        "name": "Qualitech Électricité Inc.",
+        "url": "https://qualitechelectricite.com/",
+        "image": "https://qualitechelectricite.com/assets/images/QE%20Logo.webp",
+        "logo": "https://qualitechelectricite.com/assets/images/QE%20Logo.webp",
+        "telephone": "+1-514-806-9323",
+        "email": "info@qualitechelectricite.com",
+        "priceRange": "$$",
+        "sameAs": ["https://www.google.com/maps/place/?q=place_id:ChIJqQRrBgHz6WcRfIX0O20m8-k"],
+        "description": "Entrepreneur en électricité résidentielle, commerciale et industrielle desservant Saint-Jean-sur-Richelieu, la Rive-Sud et le Grand Montréal.",
+        "identifier": {
+            "@type": "PropertyValue",
+            "propertyID": "RBQ",
+            "value": "5811-4398-01"
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Saint-Jean-sur-Richelieu",
+            "addressRegion": "QC",
+            "addressCountry": "CA"
+        },
+        "areaServed": "Grand Montréal et environs",
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Services électriques",
+            "itemListElement": [
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Services électriques résidentiels"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Services électriques commerciaux"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Services électriques industriels"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Installation de bornes de recharge"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Mise à niveau de panneaux électriques"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Alimentation triphasée et raccordement de machinerie"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Commandes de moteurs et automatisation industrielle"}},
+                {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Entretien préventif et dépannage"}}
+            ]
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "Installez-vous des bornes de recharge?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Oui. Qualitech peut évaluer la capacité du panneau, le câblage, l'emplacement de la borne et les besoins d'installation."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Pouvez-vous moderniser un panneau électrique?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Oui. Les mises à niveau de panneaux, les circuits additionnels et les travaux de modernisation sont offerts pour les projets résidentiels, commerciaux et industriels."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Offrez-vous des services électriques industriels?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Oui. Les services industriels comprennent l'alimentation triphasée, le raccordement de machinerie, les commandes de moteurs, l'automatisation industrielle, l'entretien préventif et le dépannage."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Comment demander une soumission?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Appelez au 514 806 9323 ou envoyez un courriel à info@qualitechelectricite.com avec l'adresse, le type de service et des photos si possible."
+                }
+            }
+        ]
+    }
     </script>
 </head>
 
 <body>
+    <header class="site-header">
+        <a class="brand" href="/" aria-label="Accueil Qualitech Électricité">
+            <img src="assets/images/QE Logo.webp" alt="Logo Qualitech Électricité Inc." width="1200" height="200">
+        </a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+        <nav class="site-nav" id="site-nav" aria-label="Navigation principale">
+            <a href="#services">Services</a>
+            <a href="#areas">Territoire</a>
+            <a href="#reviews">Avis</a>
+            <a href="#faq">FAQ</a>
+            <a href="#contact">Contact</a>
+            <a class="nav-cta" href="tel:+15148069323">Appeler</a>
+            <a class="language-switch" href="index-en.html" lang="en" hreflang="en-CA" aria-label="View the site in English"><span class="language-long">English</span><span class="language-short" aria-hidden="true">EN</span></a>
+        </nav>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="hero-media" aria-hidden="true"></div>
+            <div class="hero-content">
+                <p class="eyebrow">Électricien à Saint-Jean-sur-Richelieu</p>
+                <h1>Travaux électriques résidentiels, commerciaux et industriels.</h1>
+                <p class="hero-copy">Qualitech Électricité Inc. dessert Saint-Jean-sur-Richelieu, la Rive-Sud et le Grand Montréal pour les bornes de recharge, les panneaux, l'alimentation triphasée, le raccordement de machinerie et l'automatisation.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="tel:+15148069323">Appeler 514 806 9323</a>
+                    <a class="button secondary" href="#quote" hidden>Demander une soumission</a>
+                </div>
+                <dl class="trust-list">
+                    <div><dt>Située à</dt><dd>Saint-Jean-sur-Richelieu</dd></div>
+                    <div><dt>Service</dt><dd>Résidentiel, commercial et industriel</dd></div>
+                    <div><dt>Spécialités</dt><dd>Panneaux, bornes, contrôles industriels</dd></div>
+                </dl>
+            </div>
+        </section>
+
+        <section class="section intro" aria-labelledby="intro-title">
+            <div class="section-header">
+                <p class="eyebrow">Entrepreneur électricien local</p>
+                <h2 id="intro-title">Des conseils clairs, une installation soignée et un suivi fiable.</h2>
+            </div>
+            <div class="intro-copy">
+                <p>Pour une rénovation résidentielle, un espace commercial ou industriel, un raccordement de machinerie ou une modernisation des systèmes électriques et de contrôle, Qualitech réalise des projets planifiés, de l'entretien préventif et du dépannage.</p>
+                <p>Les clients trouvent rapidement les services, les coordonnées et les informations utiles avant le premier appel.</p>
+            </div>
+        </section>
+
+        <section class="section services" id="services" aria-labelledby="services-title">
+            <div class="section-header">
+                <p class="eyebrow">Services électriques</p>
+                <h2 id="services-title">Soutien pour les appels de service et les mises à niveau planifiées.</h2>
+            </div>
+            <div class="service-grid">
+                <article class="service-card">
+                    <img src="assets/images/residential.webp" alt="Travaux de câblage électrique résidentiel" width="640" height="420" loading="lazy">
+                    <div><h3>Électricité résidentielle</h3><p>Réparations, nouveaux circuits, éclairage, recâblage, améliorations de sécurité et travaux pour rénovations.</p></div>
+                </article>
+                <article class="service-card">
+                    <img src="assets/images/commercial.webp" alt="Panneaux et contrôles électriques commerciaux et industriels" width="640" height="420" loading="lazy">
+                    <div><h3>Électricité commerciale et industrielle</h3><p>Installations électriques, éclairage, alimentation triphasée, raccordement de machinerie, entretien préventif et dépannage.</p></div>
+                </article>
+                <article class="service-card">
+                    <img src="assets/images/automation.webp" alt="Équipement d'automatisation industrielle et de commande de moteurs" width="640" height="420" loading="lazy">
+                    <div><h3>Automatisation et contrôles</h3><p>Commandes de moteurs, automatisation industrielle, éclairage intelligent, contrôle climatique, accès à distance et gestion de l'énergie.</p></div>
+                </article>
+            </div>
+            <article class="industrial-callout" aria-labelledby="industrial-title">
+                <div><p class="eyebrow">Capacité industrielle</p><h3 id="industrial-title">Puissance et contrôles pour les opérations industrielles.</h3></div>
+                <p>Qualitech raccorde les équipements triphasés et la machinerie, installe les commandes de moteurs et l'automatisation, et soutient les installations avec l'entretien préventif et le dépannage électrique.</p>
+            </article>
+            <ul class="feature-list" aria-label="Services souvent demandés">
+                <li>Mise à niveau de panneaux</li><li>Bornes de recharge</li><li>Alimentation triphasée</li><li>Raccordement de machinerie</li><li>Commandes de moteurs</li><li>Automatisation industrielle</li><li>Entretien préventif</li><li>Dépannage</li>
+            </ul>
+        </section>
+
+        <section class="section split service-area" id="areas" aria-labelledby="areas-title">
+            <iframe class="service-area__map" src="https://www.openstreetmap.org/export/embed.html?bbox=-74.10%2C45.20%2C-73.05%2C45.84&amp;layer=mapnik" title="Carte du territoire desservi dans le Grand Montréal" loading="lazy" referrerpolicy="no-referrer" tabindex="-1"></iframe>
+            <div class="service-area__content">
+                <p class="eyebrow">Territoire</p>
+                <h2 id="areas-title">Au service du Grand Montréal et des environs.</h2>
+                <p>Basée à Saint-Jean-sur-Richelieu, Qualitech dessert une clientèle résidentielle, commerciale et industrielle dans toute la région.</p>
+            </div>
+            <small class="map-attribution">Données cartographiques © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">contributeurs OpenStreetMap</a></small>
+        </section>
+
+        <section class="section reviews" id="reviews" aria-labelledby="reviews-title">
+            <div class="review-panel">
+                <p class="eyebrow">Avis Google</p>
+                <h2 id="reviews-title">Consultez les avis clients sur Google.</h2>
+                <p>Quelques commentaires de clients ayant évalué Qualitech sur Google.</p>
+                <div class="review-grid">
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 étoiles sur 5">★★★★★</div>
+                        <blockquote><p>« On a eu une solide urgence un samedi matin. On avait besoin d'un électricien immédiatement. [&hellip;] »</p></blockquote>
+                        <figcaption>Julie Couture</figcaption>
+                    </figure>
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 étoiles sur 5">★★★★★</div>
+                        <blockquote><p>« Yuri est ponctuel, il a tout fait rapidement, clairement, en toute confiance. »</p></blockquote>
+                        <figcaption>Vladyslav Kazantsev</figcaption>
+                    </figure>
+                    <figure class="review-card">
+                        <div class="review-stars" role="img" aria-label="5 étoiles sur 5">★★★★★</div>
+                        <blockquote><p>« Excellent service, toujours très professionnel et agréable!! »</p></blockquote>
+                        <figcaption>Tatiana Climenco</figcaption>
+                    </figure>
+                </div>
+                <div class="hero-actions">
+                    <a class="button primary" href="https://www.google.com/maps/place/Qualitech+%C3%89lectricit%C3%A9+Inc./@45.2751445,-73.2690391,17z/data=!4m8!3m7!1s0x67e9f301066b04a9:0xe9f3266d3bf4857c!8m2!3d45.2751445!4d-73.2690391!9m1!1b1!16s%2Fg%2F11vyqr8wj1?entry=ttu&amp;hl=fr-CA" target="_blank" rel="noopener noreferrer">Lire tous les avis Google</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section faq" id="faq" aria-labelledby="faq-title">
+            <div class="section-header">
+                <p class="eyebrow">Questions</p>
+                <h2 id="faq-title">Questions fréquentes sur les services électriques.</h2>
+            </div>
+            <div class="faq-grid">
+                <article><h3>Installez-vous des bornes de recharge?</h3><p>Oui. Qualitech peut évaluer la capacité du panneau, le câblage, l'emplacement de la borne et les besoins d'installation.</p></article>
+                <article><h3>Pouvez-vous moderniser un panneau électrique?</h3><p>Oui. Les mises à niveau de panneaux, les circuits additionnels et les travaux de modernisation sont offerts pour les projets résidentiels, commerciaux et industriels.</p></article>
+                <article><h3>Offrez-vous des services électriques industriels?</h3><p>Oui. Les services industriels comprennent l'alimentation triphasée, le raccordement de machinerie, les commandes de moteurs, l'automatisation industrielle, l'entretien préventif et le dépannage.</p></article>
+                <article><h3>Comment demander une soumission?</h3><p>Appelez au 514 806 9323 ou envoyez un courriel à info@qualitechelectricite.com avec l'adresse, le type de service et des photos si possible.</p></article>
+            </div>
+        </section>
+
+        <section class="section quote-section" id="quote" aria-labelledby="quote-title" hidden>
+            <div class="quote-intro">
+                <p class="eyebrow">Demande de soumission</p>
+                <h2 id="quote-title">Parlez-nous de votre projet électrique.</h2>
+                <p>Remplissez les renseignements ci-dessous. Votre application courriel s’ouvrira avec un message préparé que vous pourrez vérifier, compléter et envoyer à Qualitech.</p>
+                <p class="form-note">Aucun renseignement n’est enregistré par ce site. Vous pourrez joindre des photos directement dans votre courriel avant de l’envoyer.</p>
+            </div>
+            <form class="quote-form" action="mailto:info@qualitechelectricite.com" method="post" enctype="text/plain" data-quote-form data-subject="Demande de soumission — site Web Qualitech" data-ready-message="Votre demande a été préparée. Vérifiez votre application courriel pour l’envoyer.">
+                <div class="form-grid">
+                    <label>Nom complet <span aria-hidden="true">*</span><input type="text" name="name" autocomplete="name" maxlength="100" required data-field-label="Nom"></label>
+                    <label>Courriel <span aria-hidden="true">*</span><input type="email" name="email" autocomplete="email" maxlength="254" required data-field-label="Courriel"></label>
+                    <label>Téléphone<input type="tel" name="phone" autocomplete="tel" inputmode="tel" maxlength="40" data-field-label="Téléphone"></label>
+                    <label>Ville du projet <span aria-hidden="true">*</span><input type="text" name="city" autocomplete="address-level2" maxlength="100" required data-field-label="Ville du projet"></label>
+                    <label class="form-span">Type de service <span aria-hidden="true">*</span>
+                        <select name="service" required data-field-label="Type de service">
+                            <option value="">Sélectionnez un service</option>
+                            <option>Résidentiel</option>
+                            <option>Commercial</option>
+                            <option>Industriel</option>
+                            <option>Borne de recharge</option>
+                            <option>Panneau électrique</option>
+                            <option>Automatisation et contrôles</option>
+                            <option>Dépannage</option>
+                            <option>Autre</option>
+                        </select>
+                    </label>
+                    <label class="form-span">Décrivez les travaux <span aria-hidden="true">*</span><textarea name="details" rows="6" maxlength="2000" required data-field-label="Description des travaux" placeholder="Décrivez le problème, l’installation ou la mise à niveau souhaitée."></textarea></label>
+                    <label class="form-span">Échéancier souhaité<input type="text" name="timing" maxlength="160" data-field-label="Échéancier souhaité" placeholder="Par exemple : dès que possible, ce mois-ci ou une date précise"></label>
+                </div>
+                <button class="button primary" type="submit">Préparer ma demande</button>
+                <p class="form-status" data-form-status aria-live="polite"></p>
+            </form>
+        </section>
+
+        <section class="contact-section" id="contact" aria-labelledby="contact-title">
+            <div>
+                <p class="eyebrow">Contact</p>
+                <h2 id="contact-title">Parlez à un électricien.</h2>
+                <p>Indiquez l'emplacement du projet, le type de travaux et le moment souhaité. Des photos du panneau ou de la zone d'installation peuvent aider à préparer une première estimation.</p>
+            </div>
+            <address class="contact-card">
+                <a href="tel:+15148069323">514 806 9323</a>
+                <a class="email-copy" href="mailto:info@qualitechelectricite.com" data-copy-email="info@qualitechelectricite.com" data-copy-success="Adresse courriel copiée" data-copy-failure="Impossible de copier; ouverture de votre application courriel."><span>info@qualitechelectricite.com</span><small>Cliquer pour copier</small></a>
+                <span>Basée à Saint-Jean-sur-Richelieu, QC</span>
+            </address>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year">2026</span> Qualitech Électricité Inc. Tous droits réservés.</p>
+        <p class="footer-rbq">RBQ&nbsp;: 5811-4398-01</p>
+    </footer>
+
+    <a class="mobile-call" href="tel:+15148069323">Appeler 514 806 9323</a>
+    <script src="assets/js/main.js?v=20260719g" defer></script>
 </body>
 
 </html>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,36 @@
+# Qualitech Électricité Inc.
+
+Qualitech Électricité Inc. is a residential, commercial, and industrial electrical contractor based in Saint-Jean-sur-Richelieu, QC.
+
+Website: https://qualitechelectricite.com/
+Phone: +1 514 806 9323
+Email: info@qualitechelectricite.com
+
+## Services
+
+- Residential electrical repairs, wiring, lighting, panels, and renovations
+- Commercial electrical installations, lighting, maintenance, and safety systems
+- Industrial electrical services, including three-phase power and machinery connections
+- Motor controls and industrial automation
+- Preventive electrical maintenance and troubleshooting
+- EV charger installation for homes and businesses
+- Electrical panel upgrades and added circuits
+- Smart lighting, climate controls, remote access, and energy management
+
+## Terminologie française
+
+- Services électriques résidentiels, commerciaux et industriels
+- Alimentation triphasée et raccordement de machinerie
+- Commandes de moteurs et automatisation industrielle
+- Entretien préventif et dépannage électrique
+- Bornes de recharge et mise à niveau de panneaux
+
+## Service areas
+
+- Greater Montreal and surrounding areas / Grand Montréal et environs
+- Based in Saint-Jean-sur-Richelieu, QC
+
+## Pages
+
+- French (default): https://qualitechelectricite.com/
+- English: https://qualitechelectricite.com/index-en.html

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://qualitechelectricite.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    <url>
+        <loc>https://qualitechelectricite.com/</loc>
+        <lastmod>2026-07-19</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+        <xhtml:link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html"/>
+        <xhtml:link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/"/>
+    </url>
+    <url>
+        <loc>https://qualitechelectricite.com/index-en.html</loc>
+        <lastmod>2026-07-19</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+        <xhtml:link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html"/>
+        <xhtml:link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/"/>
+    </url>
+</urlset>


### PR DESCRIPTION
## Summary

- Redesigns `index.html` / `index-en.html` / `index-fr.html` from the old carousel layout into a full bilingual page: hero, services, service area (map), Google reviews, FAQ, quote-request form (currently hidden pending a submission backend), and contact.
- Adds SEO support: `Electrician` + `FAQPage` JSON-LD, canonical/hreflang tags, `robots.txt`, `sitemap.xml`, `llms.txt`, and a bilingual `404.html`.
- Accessibility: semantic `ul/li` for the feature-chip list, `role="img"` on star ratings, hamburger icon animates to a ✕ while the mobile menu is open.
- UX: sticky header where the banner scrolls away and only the nav row stays pinned; language switch now preserves the current query string and section hash; click-to-copy email with a toast and `mailto:` fallback.
- Rollback safety net: tagged the prior commit as [`pre-redesign`](https://github.com/skhomenko/qualitech-el/releases/tag/pre-redesign) and cut a matching GitHub Release before this change, so the classic carousel site can be restored with `git revert` if needed.

## Test plan

Verified locally against a static server and cross-checked against the live site (qualitechelectricite.com):
- [x] FR and EN pages render correctly on desktop and mobile viewports
- [x] Language switch round-trips (FR → EN → FR) and preserves query string/hash
- [x] Mobile menu opens/closes; hamburger icon toggles to ✕
- [x] Click-to-copy email shows the toast and copies the address
- [x] `404.html` renders correctly when loaded directly
- [x] JSON-LD blocks parse as valid JSON on all three pages
- [x] Confirm GitHub Pages' custom-404 detection picks up `404.html` after this merges