### PR TITLE
fix(header): make RBQ number readable at every width

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#F5F5F2">
     <meta name="robots" content="noindex, follow">
     <title>Page introuvable — Page not found | Qualitech Électricité</title>
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260719h">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260719j">
     <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon">
 </head>
 
@@ -15,6 +15,14 @@
     <header class="site-header">
         <a class="brand" href="/" aria-label="Accueil Qualitech Électricité">
             <img src="/assets/images/QE Logo.webp" alt="Logo Qualitech Électricité Inc." width="1200" height="200">
+            <span class="mobile-brand-lockup" aria-hidden="true">
+                <span class="mobile-qe-mark"><img src="/assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                <span class="mobile-brand-copy">
+                    <span class="mobile-wordmark"><img src="/assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                    <span class="mobile-rbq">RBQ&nbsp;: 5811-4398-01</span>
+                </span>
+            </span>
+            <span class="brand-rbq">RBQ&nbsp;: 5811-4398-01</span>
         </a>
     </header>
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -105,16 +105,35 @@ a {
 }
 
 .brand {
+    position: relative;
     display: flex;
     justify-content: center;
     padding: 18px clamp(18px, 4vw, 56px) 14px;
     border-top: 5px solid var(--brand-orange);
     background: var(--warm-white);
+    text-decoration: none;
 }
 
-.brand img {
+.brand > img {
     width: min(86vw, 1040px);
     height: auto;
+}
+
+.mobile-brand-lockup {
+    display: none;
+}
+
+.brand-rbq {
+    position: absolute;
+    right: calc(max(7vw, 50% - 520px) + 24px);
+    bottom: 20px;
+    padding: 2px 4px;
+    background: rgb(var(--warm-white-rgb) / 0.96);
+    color: var(--carbon);
+    font-size: clamp(0.82rem, 1vw, 0.95rem);
+    font-weight: 900;
+    line-height: 1.15;
+    white-space: nowrap;
 }
 
 .site-nav {
@@ -887,8 +906,16 @@ h3 {
         border-top: 0;
     }
 
-    .brand img {
+    .brand > img {
         width: min(74vw, 620px);
+    }
+
+    .brand-rbq {
+        /* Track the right edge of the left-aligned tablet logo, including its 18px inset. */
+        right: calc(100% - min(74vw, 620px) - 18px);
+        bottom: 15px;
+        padding: 1px 3px;
+        font-size: 0.75rem;
     }
 
     .menu-toggle {
@@ -984,8 +1011,72 @@ h3 {
         padding-bottom: 64px;
     }
 
-    .brand img {
-        width: min(74vw, 430px);
+    .brand {
+        min-height: 75px;
+        padding: 7px 0 7px 12px;
+    }
+
+    .brand > img,
+    .brand > .brand-rbq {
+        display: none;
+    }
+
+    .mobile-brand-lockup {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .mobile-qe-mark,
+    .mobile-wordmark {
+        position: relative;
+        flex: 0 0 auto;
+        overflow: hidden;
+    }
+
+    .mobile-qe-mark {
+        width: clamp(82px, 24vw, 96px);
+        aspect-ratio: 395 / 185;
+    }
+
+    .mobile-wordmark {
+        width: clamp(132px, 38vw, 150px);
+        aspect-ratio: 470 / 132;
+    }
+
+    .mobile-qe-mark img,
+    .mobile-wordmark img {
+        position: absolute;
+        max-width: none;
+        height: auto;
+    }
+
+    /* Crops map to (80, 5)–(475, 190) and (570, 20)–(1040, 152) in QE Logo.webp. */
+    .mobile-qe-mark img {
+        top: -2.7%;
+        left: -20.25%;
+        width: 303.8%;
+    }
+
+    .mobile-wordmark img {
+        top: -15.15%;
+        left: -121.28%;
+        width: 255.32%;
+    }
+
+    .mobile-brand-copy {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+    }
+
+    .mobile-rbq {
+        color: var(--carbon);
+        font-size: 0.75rem;
+        font-weight: 900;
+        line-height: 1.1;
+        white-space: nowrap;
     }
 
     .site-header::after {

--- a/index-en.html
+++ b/index-en.html
@@ -29,7 +29,7 @@
     <link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html">
     <link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/">
     <link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/">
-    <link rel="stylesheet" href="assets/css/styles.css?v=20260719h">
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260719j">
     <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
     <script type="application/ld+json">
     {
@@ -119,6 +119,14 @@
     <header class="site-header">
         <a class="brand" href="/" aria-label="Qualitech Electricite home">
             <img src="assets/images/QE Logo.webp" alt="Qualitech Électricité Inc. logo" width="1200" height="200">
+            <span class="mobile-brand-lockup" aria-hidden="true">
+                <span class="mobile-qe-mark"><img src="assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                <span class="mobile-brand-copy">
+                    <span class="mobile-wordmark"><img src="assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                    <span class="mobile-rbq">RBQ: 5811-4398-01</span>
+                </span>
+            </span>
+            <span class="brand-rbq">RBQ: 5811-4398-01</span>
         </a>
         <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
             <span></span>

--- a/index-fr.html
+++ b/index-fr.html
@@ -29,7 +29,7 @@
     <link rel="alternate" hreflang="en-CA" href="https://qualitechelectricite.com/index-en.html">
     <link rel="alternate" hreflang="fr-CA" href="https://qualitechelectricite.com/">
     <link rel="alternate" hreflang="x-default" href="https://qualitechelectricite.com/">
-    <link rel="stylesheet" href="assets/css/styles.css?v=20260719h">
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260719j">
     <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
     <script type="application/ld+json">
     {
@@ -119,6 +119,14 @@
     <header class="site-header">
         <a class="brand" href="/" aria-label="Accueil Qualitech Électricité">
             <img src="assets/images/QE Logo.webp" alt="Logo Qualitech Électricité Inc." width="1200" height="200">
+            <span class="mobile-brand-lockup" aria-hidden="true">
+                <span class="mobile-qe-mark"><img src="assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                <span class="mobile-brand-copy">
+                    <span class="mobile-wordmark"><img src="assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                    <span class="mobile-rbq">RBQ&nbsp;: 5811-4398-01</span>
+                </span>
+            </span>
+            <span class="brand-rbq">RBQ&nbsp;: 5811-4398-01</span>
         </a>
         <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
             <span></span>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         // Storage can be unavailable in privacy-restricted browsing modes.
     }
     </script>
-    <link rel="stylesheet" href="assets/css/styles.css?v=20260719h">
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260719j">
     <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
     <script type="application/ld+json">
     {
@@ -128,6 +128,14 @@
     <header class="site-header">
         <a class="brand" href="/" aria-label="Accueil Qualitech Électricité">
             <img src="assets/images/QE Logo.webp" alt="Logo Qualitech Électricité Inc." width="1200" height="200">
+            <span class="mobile-brand-lockup" aria-hidden="true">
+                <span class="mobile-qe-mark"><img src="assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                <span class="mobile-brand-copy">
+                    <span class="mobile-wordmark"><img src="assets/images/QE Logo.webp" alt="" width="1200" height="200"></span>
+                    <span class="mobile-rbq">RBQ&nbsp;: 5811-4398-01</span>
+                </span>
+            </span>
+            <span class="brand-rbq">RBQ&nbsp;: 5811-4398-01</span>
         </a>
         <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="site-nav">
             <span></span>


### PR DESCRIPTION
The RBQ license number was baked into the header logo image, so it shrank to unreadable size on mobile and was easy to miss elsewhere.

- Add a mobile-only lockup (cropped mark + wordmark) with the RBQ as real, bold text below 640px.
- Add a badge that overlays real text on the baked-in RBQ for 641-1120px and above 1120px, positioned flush with the logo's right edge so it fully covers the original number without doubling it.
- Remove the link underline on the brand lockup.
- Document the mobile crop coordinates against QE Logo.webp.
- Bump styles.css cache-busting query to v=20260719j.

Applied to index.html, index-en.html, index-fr.html, and 404.html.

Test: verified at 390, 640, 641, 768, 1000, 1120, 1121, and 1440px in-browser; no doubled RBQ text or horizontal overflow.